### PR TITLE
adding device and dtype args to perplexity

### DIFF
--- a/transformer_tricks.py
+++ b/transformer_tricks.py
@@ -231,7 +231,7 @@ def hello_world(repo, max_new_tok=4, arch='AutoModelForCausalLM', perf=False):
   #  transformers.logging.set_verbosity_error()
 
 
-def perplexity(repo, speedup=1, arch='AutoModelForCausalLM', bars=False, perf=False):
+def perplexity(repo, speedup=1, arch='AutoModelForCausalLM', bars=False, perf=False, device='cpu', dtype=None):
   """calculate perplexity of an LLM with wikitext2
   this def is copied from https://huggingface.co/docs/transformers/perplexity
   I made the following changes to adapt it for SmolLM (was GPT2 before):
@@ -248,7 +248,12 @@ def perplexity(repo, speedup=1, arch='AutoModelForCausalLM', bars=False, perf=Fa
   # TODO: consider using instead 'with torch.no_grad():'
 
   tok = AutoTokenizer.from_pretrained(repo)
-  model = eval(f'{arch}.from_pretrained(repo, low_cpu_mem_usage=True)')
+
+  kwargs = {'low_cpu_mem_usage': True}
+  if dtype is not None:
+    kwargs['torch_dtype'] = dtype
+
+  model = eval(f'{arch}.from_pretrained(repo, **kwargs)').to(device)
 
   # tokenize wikitext2
   test = datasets.load_dataset('wikitext', 'wikitext-2-raw-v1', split='test')
@@ -265,7 +270,7 @@ def perplexity(repo, speedup=1, arch='AutoModelForCausalLM', bars=False, perf=Fa
   for begin_loc in tqdm(range(0, seq_len, stride), disable=not bars):
     end_loc = min(begin_loc + max_length, seq_len)
     trg_len = end_loc - prev_end_loc  # may be different from stride on last loop
-    input_ids = encodings.input_ids[:, begin_loc:end_loc].to('cpu')
+    input_ids = encodings.input_ids[:, begin_loc:end_loc].to(device)
     target_ids = input_ids.clone()
     target_ids[:, :-trg_len] = -100
     outputs = model(input_ids, labels=target_ids)
@@ -285,6 +290,7 @@ def perplexity(repo, speedup=1, arch='AutoModelForCausalLM', bars=False, perf=Fa
         f'  (time: {time.perf_counter() - start_time:.2f}s)' if perf else '')
   # print('nlls:', nlls)
   del model; gc.collect()  # run garbage collection
+  return ppl.item()
 
 
 #-------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently, perplexity() is currently to CPU, which makes iterative experiments slow, and I couldn't get full-wikitext runs to finish for Llama-3.2-1B within reasonable time. This PR adds optional device= and dtype= arguments, defaulting to current behavior (None) so existing callers are unaffected. Also changes the function to return ppl.item() so callers can build tables for data collection.

Verified on SmolLM2-135M, speedup=16:

- CPU (default): 13.128, ~5 min 30 sec
- CUDA fp32: 13.113, ~6 sec (55x speedup)

For three precision sweeps (bp16, fp16, fp32), total execution time is ~101.5 seconds.

The small (~0.1%) rounding drift between CPU and CUDA matmul paths is expected.
Intended for scaling MatShrink experiments to Llama-3.2-1B