### PR TITLE
Add MatShrink V-O notebook

### DIFF
--- a/notebooks/matShrink_paper.ipynb
+++ b/notebooks/matShrink_paper.ipynb
@@ -1,0 +1,142 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FYlbd9CxHwh-"
+      },
+      "source": [
+        "Matching SlimAttention form and shortening from v1/test notebook"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WjiK2HzMqImN",
+        "outputId": "494234d8-1b0d-4142-c080-5a78fe6d7775"
+      },
+      "outputs": [],
+      "source": [
+        "# Proof of concept for MatShrink paper\n",
+        "# Usage: python3 matShrink_paper.py\n",
+        "\n",
+        "%pip install --quiet git+https://github.com/siddhshah/transformer-tricks.git@perplexity-device-arg # branch containing device and dtype arg updates\n",
+        "import transformer_tricks as tt\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "from transformers import AutoConfig\n",
+        "\n",
+        "# defs\n",
+        "def matshrink_vo(param, config, storage_dtype=torch.float16):\n",
+        "  \"\"\"Apply V-O MatShrink to all layers of a Llama-family model.\n",
+        "     Math in fp64; weights written back in storage_dtype.\n",
+        "     Per KV group, pick M as first dk rows of the first query head's O slice.\"\"\"\n",
+        "  h, h_kv = config.num_attention_heads, config.num_key_value_heads\n",
+        "  g, dk = h // h_kv, config.head_dim\n",
+        "\n",
+        "  for layer in range(config.num_hidden_layers):\n",
+        "    # note: all weights are transposed in tensorfile\n",
+        "    Wv = param[tt.weight('V', layer)].to(torch.float64).numpy().T\n",
+        "    Wo = param[tt.weight('O', layer)].to(torch.float64).numpy().T\n",
+        "\n",
+        "    for kv in range(h_kv):\n",
+        "      q0 = kv * g\n",
+        "      M = Wo[q0*dk:(q0+1)*dk, :dk].copy()\n",
+        "      M_inv = np.linalg.inv(M)\n",
+        "      Wv[:, kv*dk:(kv+1)*dk] = Wv[:, kv*dk:(kv+1)*dk] @ M\n",
+        "      for q in range(q0, q0 + g):\n",
+        "        Wo[q*dk:(q+1)*dk, :] = M_inv @ Wo[q*dk:(q+1)*dk, :]\n",
+        "\n",
+        "    param[tt.weight('V', layer)] = torch.from_numpy(Wv.T).to(storage_dtype).contiguous()\n",
+        "    param[tt.weight('O', layer)] = torch.from_numpy(Wo.T).to(storage_dtype).contiguous()\n",
+        "\n",
+        "def matshrink_repo(repo, out_dir, storage_dtype=torch.float16):\n",
+        "  param = tt.get_param(repo)\n",
+        "  config = AutoConfig.from_pretrained(repo)\n",
+        "  matshrink_vo(param, config, storage_dtype=storage_dtype)\n",
+        "  tt.save_repo(repo, param, config, out_dir)\n",
+        "\n",
+        "# setup\n",
+        "tt.quiet_hf()\n",
+        "repo = 'HuggingFaceTB/SmolLM2-135M'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8K_QqCsJqb81",
+        "outputId": "3df3e9ef-8faa-4b53-b3ae-7ff248879774"
+      },
+      "outputs": [],
+      "source": [
+        "# check that V@O composition is preserved per head after MatShrink\n",
+        "param_orig = tt.get_param(repo)\n",
+        "param_new  = tt.get_param(repo)\n",
+        "config = AutoConfig.from_pretrained(repo)\n",
+        "matshrink_vo(param_new, config, storage_dtype=torch.float64)\n",
+        "\n",
+        "h, h_kv = config.num_attention_heads, config.num_key_value_heads\n",
+        "g, dk = h // h_kv, config.head_dim\n",
+        "\n",
+        "for layer in range(config.num_hidden_layers):\n",
+        "  Wv0 = param_orig[tt.weight('V', layer)].to(torch.float64).numpy().T\n",
+        "  Wo0 = param_orig[tt.weight('O', layer)].to(torch.float64).numpy().T\n",
+        "  Wv1 = param_new [tt.weight('V', layer)].to(torch.float64).numpy().T\n",
+        "  Wo1 = param_new [tt.weight('O', layer)].to(torch.float64).numpy().T\n",
+        "  ok = all(np.allclose(Wv0[:, (q//g)*dk:(q//g+1)*dk] @ Wo0[q*dk:(q+1)*dk, :],\n",
+        "                       Wv1[:, (q//g)*dk:(q//g+1)*dk] @ Wo1[q*dk:(q+1)*dk, :])\n",
+        "           for q in range(h))\n",
+        "  print(layer, ':', ok)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "SM0yyubFqcms",
+        "outputId": "8a925ba0-2491-4e37-b137-bba40bc4aabc"
+      },
+      "outputs": [],
+      "source": [
+        "# perplexity: baseline vs MatShrink at three storage precisions\n",
+        "speedup = 16 # you should set this to 1 for full wikitext-2 (still faster on GPU)\n",
+        "\n",
+        "for name, dt in [('bf16', torch.bfloat16), ('fp16', torch.float16), ('fp32', torch.float32)]:\n",
+        "  print(f'--- {name} ---')\n",
+        "  print('baseline:  ', end='')\n",
+        "  tt.perplexity(repo, speedup=speedup, device='cuda', dtype=dt)\n",
+        "  out_dir = f'./SmolLM2-135M_matshrink_{name}'\n",
+        "  matshrink_repo(repo, out_dir, storage_dtype=dt)\n",
+        "  print('matshrink: ', end='')\n",
+        "  tt.perplexity(out_dir, speedup=speedup, device='cuda', dtype=dt)"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Adds a proof-of-concept notebook for MatShrink V-O on SmolLM2-135M.

**Cells**:
1. Cell 1: matshrink_vo() and matshrink_repo() using tt.weight(), numpy with transposed math-convention arrays, fp64 inversion, storage dtype configurable.
2. Cell 2: Per-layer, per-head V@O composition check. All 30 × 9 = 270 pairs pass in fp64.
3. Cell 3: Baseline vs MatShrink perplexity at bf16 / fp16 / fp32 storage using tt.perplexity.

**Results**:
dtype | baseline | matshrink | diff
-- | -- | -- | --
bf16 | 13.120 | 14.547 | +1.43
fp16 | 13.112 | 13.124 | +0.012
fp32 | 13.113 | 13.113 | 0.000

fp16 storage is effectively lossless (+0.09%); bf16 degrades due to fewer precision bits compared to fp16.

**Notes**:
- Uses speedup=16 as shown in flashNorm_example.py. The full-wikitext numbers for the paper are in a separate run.
- Depends on PR #10 (device/dtype args to tt.perplexity) for the three-precision sweep in Cell 3 to run in reasonable time (GPU is still faster, but using the full wikitext will just take longer total execution time in general for data collection purposes).