### PR TITLE
FlashNorm: surface +12.77% realized HF end-to-end speedup in the abstract

### DIFF
--- a/tex/flashNorm.tex
+++ b/tex/flashNorm.tex
@@ -66,8 +66,9 @@ The same techniques extend to LayerNorm, Dynamic Tanh (DyT), feed-forward networ
 with GLU variants, and RoPE-based attention.
 On an NVIDIA T4 GPU, FlashNorm achieves \textbf{33--35\%}
 lower latency on the norm-then-project operation in the compute-bound (prefill)
-regime at SmolLM2-135M scale, and \textbf{12--14\%} at Llama-7B scale. We verify
-zero-loss weight folding on three models.
+regime at SmolLM2-135M scale, and \textbf{12--14\%} at Llama-7B scale.
+At decode on Llama-3.2-1B in stock HuggingFace Transformers (NVIDIA A100, bf16), routing through PyTorch's existing weightless C++ kernel yields \textbf{$+12.77\%$} end-to-end (Appendix~\ref{app:rmsnorm-fraction}).
+We verify zero-loss weight folding on three models.
 Beyond inference speed, FlashNorm simplifies model implementations by
 reducing parameter tensor count.
 Watch our explainer video \citep{flashNorm-video} and see

--- a/tex/flashNorm.tex
+++ b/tex/flashNorm.tex
@@ -67,7 +67,7 @@ with GLU variants, and RoPE-based attention.
 On an NVIDIA T4 GPU, FlashNorm achieves \textbf{33--35\%}
 lower latency on the norm-then-project operation in the compute-bound (prefill)
 regime at SmolLM2-135M scale, and \textbf{12--14\%} at Llama-7B scale.
-At decode on Llama-3.2-1B in stock HuggingFace Transformers (NVIDIA A100, bf16), routing through PyTorch's existing weightless C++ kernel yields \textbf{$+12.77\%$} end-to-end (Appendix~\ref{app:rmsnorm-fraction}).
+On an NVIDIA A100 at bf16, FlashNorm achieves a \textbf{$+12.77\%$} end-to-end speedup at decode on Llama-3.2-1B in stock HuggingFace Transformers, via PyTorch's existing weightless C++ kernel (Appendix~\ref{app:rmsnorm-fraction}).
 We verify zero-loss weight folding on three models.
 Beyond inference speed, FlashNorm simplifies model implementations by
 reducing parameter tensor count.


### PR DESCRIPTION
## Summary

Adds one sentence to the abstract reporting the realized end-to-end speedup of FlashNorm Proposition 1 in stock HuggingFace Transformers: **+12.77%** on Llama-3.2-1B at bf16, NVIDIA A100, 256-token greedy decode. Surfaces the headline number in the abstract; the supporting measurement and reproducibility notebook are already in main from #14.

The added sentence:

> At decode on Llama-3.2-1B in stock HuggingFace Transformers (NVIDIA A100, bf16), routing through PyTorch's existing weightless C++ kernel yields **+12.77%** end-to-end (Appendix~\ref{app:rmsnorm-fraction}).

## What's in this PR

| File | Change |
|---|---|
| `tex/flashNorm.tex` | One sentence inserted into the abstract, between the T4 GPU benchmark sentence and the zero-loss verification sentence. |

Net diff: +3 / -2 lines (one new sentence; the existing T4 sentence's trailing words flow to a new line). Estimated PDF page-impact: roughly one line in the rendered abstract.

## Why a separate PR (not bundled into #14)

The realized-speedup measurement, the reproducibility notebook (`notebooks/flashNorm_hf_a100.ipynb`), and the appendix Findings sentence already landed via #14. This PR surfaces the same number one level up, in the abstract, where reviewers see it first. Splitting keeps the diff focused: #14 was about the appendix and the bundled corrections to the merged PR #13 content; this PR is just the abstract pointer.

## Companion artifacts (already in main)

- Reproducibility notebook: `notebooks/flashNorm_hf_a100.ipynb` (8-cell Colab A100, ~3 min wall-clock).
- Appendix measurement: `app:rmsnorm-fraction` Findings paragraph, "Roughly half of this fraction is recoverable today via a runtime swap of `LlamaRMSNorm.forward`...".
- Upstream-integration follow-ups for vLLM and llama.cpp: cited in the #14 PR description (`vllm-project/vllm#41431`, `vllm-project/vllm#41430`, `ggml-org/llama.cpp#22486`).

## Status

Open for review.
