### PR TITLE
flashNorm: rename Discussion section to Limitations and Discussion

### DIFF
--- a/tex/flashNorm.tex
+++ b/tex/flashNorm.tex
@@ -530,7 +530,7 @@ Tokens & Sequential & FlashNorm & Speedup & Path \\
 
 FlashNorm uses adaptive dispatch: the parallel path is used only when the GEMM is compute-bound (token count exceeds a hardware-dependent threshold). For memory-bound workloads such as autoregressive decoding, FlashNorm falls back to sequential execution (0\% overhead). This is because managing parallel CUDA streams introduces scheduling overhead that exceeds the time saved when the GEMM is small. At autoregressive decode on \texttt{Llama-3.2-1B-Instruct} in HuggingFace Transformers, RMSNorm operations occupy 24.6\% of total wall-clock at bf16, an order of magnitude above their FLOP share; the cumulative norm cost is invariant under weight quantization, so the relative impact of FlashNorm grows in deployments that aggressively quantize linears (Appendix~\ref{app:rmsnorm-fraction}).
 
-\section{Discussion}
+\section{Limitations and Discussion}
 
 %\paragraph{TODO: PERHAPS REMOVE THIS: When to use FlashNorm.}
 %FlashNorm provides the largest benefit in prefill-dominated workloads with long


### PR DESCRIPTION
## Summary
- Renames Section 6 from "Discussion" to "Limitations and Discussion".
- One-line change to `tex/flashNorm.tex`. No content additions, no page-budget impact.

## Motivation
NeurIPS Paper Checklist Q2 (Limitations) prefers an explicitly labeled limitations section. The existing Discussion already covers the relevant limitations:
- RMSNorm-only scope (LayerNorm not addressed; mean subtraction breaks the fold).
- Activation dynamic range under fixed-point backends.
- Adaptive dispatch fallback at small token counts (parallel path is only used when the GEMM is compute-bound).
- Prototype kernel scope on H100 (Appendix `app:h100-cutlass` analyzes the regression rows).
- Native low-bit hardware not directly measured (the GGUF-angle prediction in `app:rmsnorm-fraction` is left to follow-up).

Renaming the heading flags these as limitations without restructuring or extending the section.

## Test plan
- [ ] LaTeX build produces the same PDF with the renamed heading.
- [ ] Table of contents reflects the new section name.
- [ ] No cross-references to "Section 6" or `sec:discussion` exist in the source (verified locally; no `\label{sec:discussion}` or `\ref{sec:discussion}`).