### PR TITLE
flashNorm: norm cancellation (Prop 3) with eligibility audit and MLA partial variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ A runnable notebook version of this recipe is at [`notebooks/flashify_and_publis
 
 ---
 
+## Cancel redundant norms (Proposition 3)
+
+An RMSNorm followed by a bias-free linear layer followed by another RMSNorm makes the first norm redundant: after folding its gain into the linear layer, scale invariance of the second norm cancels the first norm's division. In QKV-normalized models such as Gemma 4 (which re-normalizes queries, keys, and values per head), this removes the entire pre-attention RMSNorm from every decoder layer.
+
+```python
+import flashNorm_cancel as fc  # from a repo checkout; not yet in the PyPI wheel
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained('google/gemma-4-E2B')
+print(fc.audit_pre_attention_cancellation(model))  # per-layer eligibility report
+fc.cancel_pre_attention_norms(model)               # fold gains, remove the division
+```
+
+The cancellation is exact for unregularized RMS and epsilon-approximate in practice. Validated on Gemma-4-E2B and Gemma-4-12B in fp32: max logit deviation at the rounding level of the exact weight fold itself, perplexity changes under 0.001%, greedy generations unchanged, HellaSwag unchanged (bf16 spot check).
+
+Important: eligibility must be checked, not assumed. In MLA models (DeepSeek-V2 family, MiniCPM3) the decoupled RoPE-key slice bypasses the latent norm, so full cancellation is invalid there (it breaks the model badly). Use `fc.mla_partial_cancel(model)` instead, which keeps the per-token RMS scalar but applies it only to the small RoPE slice, still eliminating the norm weights and the full-width multiply. Models that normalize only queries and keys (e.g. Gemma 3, no value norm) are not eligible, and `cancel_pre_attention_norms` refuses them by default. Run `python flashNorm_cancel_test.py` for a fast synthetic verification of all these cases.
+
+---
+
 ## Documentation
 Follow the links below for documentation of the python code in this directory:
 - [Slim attention](https://github.com/OpenMachine-ai/transformer-tricks/blob/main/doc/slimAttn.md)

--- a/flashNorm_cancel.py
+++ b/flashNorm_cancel.py
@@ -64,9 +64,10 @@ def fold_norm_into_projs(norm, projs, convention='auto'):
   return convention
 
 
-class _RmsScalarKeeper(nn.Module):
-  """Drop-in replacement for a bypassed RMSNorm: passes the input through unchanged but
-  records the per-token scalar s = 1/sqrt(mean(x^2) + eps) for downstream hooks."""
+class _BypassedNorm(nn.Module):
+  """Drop-in replacement for a cancelled RMSNorm: passes the input through unchanged.
+  With keep_scalar=True it also records the per-token scalar s = 1/sqrt(mean(x^2) + eps)
+  for downstream hooks (used by mla_partial_cancel)."""
 
   def __init__(self, eps, keep_scalar=True):
     super().__init__()
@@ -142,12 +143,12 @@ def cancel_pre_attention_norms(model, convention='auto', layers=None, force=Fals
                      f'use mla_partial_cancel() for MLA models or force=True to override')
   for ly in layers:
     at = ly.self_attn
-    if isinstance(ly.input_layernorm, _RmsScalarKeeper):
+    if isinstance(ly.input_layernorm, _BypassedNorm):
       raise ValueError('input_layernorm already cancelled; transforms must be applied once')
     projs = [p for p in (getattr(at, 'q_proj', None), getattr(at, 'k_proj', None),
                          getattr(at, 'v_proj', None)) if p is not None]
     fold_norm_into_projs(ly.input_layernorm, projs, convention)
-    ly.input_layernorm = _RmsScalarKeeper(_get_norm_eps(ly.input_layernorm), keep_scalar=False)
+    ly.input_layernorm = _BypassedNorm(_get_norm_eps(ly.input_layernorm), keep_scalar=False)
   return report
 
 
@@ -159,23 +160,25 @@ def mla_partial_cancel(model, convention='auto', layers=None, rope_dims=None):
   only where the eligibility criterion fails: the decoupled RoPE-key slice (the last
   rope_dims columns of kv_a_proj_with_mqa's output), plus the whole query projection
   when the model has no q_a_layernorm (e.g. DeepSeek-V2-Lite). The RMS reduction itself
-  is kept; the norm weight tensor and the hidden-width multiply are removed."""
+  is kept; the norm weight tensor and the hidden-width multiply are removed.
+  Returns a per-layer report of what was folded and where the scalar is re-applied."""
   layers = decoder_layers(model) if layers is None else layers
   if rope_dims is None:
     rope_dims = model.config.qk_rope_head_dim
-  for ly in layers:
+  report = []
+  for i, ly in enumerate(layers):
     at = ly.self_attn
     kv_a = getattr(at, 'kv_a_proj_with_mqa', None)
     assert kv_a is not None and getattr(at, 'kv_a_layernorm', None) is not None, \
         'mla_partial_cancel expects kv_a_proj_with_mqa and kv_a_layernorm'
-    if isinstance(ly.input_layernorm, _RmsScalarKeeper):
+    if isinstance(ly.input_layernorm, _BypassedNorm):
       raise ValueError('input_layernorm already cancelled; transforms must be applied once')
     q_latent = getattr(at, 'q_a_proj', None)
     q_needs_scalar = q_latent is None or getattr(at, 'q_a_layernorm', None) is None
     q_in = q_latent if q_latent is not None else getattr(at, 'q_proj', None)
     assert q_in is not None, 'could not locate the query input projection'
     fold_norm_into_projs(ly.input_layernorm, [q_in, kv_a], convention)
-    keeper = _RmsScalarKeeper(_get_norm_eps(ly.input_layernorm), keep_scalar=True)
+    keeper = _BypassedNorm(_get_norm_eps(ly.input_layernorm), keep_scalar=True)
     ly.input_layernorm = keeper
 
     def kpe_hook(mod, inp, out, s=keeper, r=rope_dims):
@@ -184,3 +187,7 @@ def mla_partial_cancel(model, convention='auto', layers=None, rope_dims=None):
     kv_a.register_forward_hook(kpe_hook)
     if q_needs_scalar:
       q_in.register_forward_hook(lambda mod, inp, out, s=keeper: out * s.s)
+    report.append({'layer': i, 'folded': ['q_a_proj' if q_latent is not None else 'q_proj',
+                                          'kv_a_proj_with_mqa'],
+                   'rope_slice_scalar': rope_dims, 'q_scalar_hook': q_needs_scalar})
+  return report

--- a/flashNorm_cancel.py
+++ b/flashNorm_cancel.py
@@ -1,0 +1,186 @@
+# FlashNorm norm cancellation (Proposition 3 of the FlashNorm paper, arXiv:2407.09577)
+#
+# An RMSNorm followed by a bias-free linear layer followed by another RMSNorm makes the
+# first RMSNorm redundant: after folding its gain into the linear layer (Proposition 1),
+# scale invariance of the second norm cancels the first norm's 1/RMS division. This module
+# applies that cancellation to loaded HuggingFace models, with an eligibility audit.
+#
+# Eligibility criterion: the pre-attention norm can be cancelled only if EVERY consumer of
+# its output is re-normalized downstream through bias-free, positively homogeneous paths.
+#   - QKV-normalized models (e.g. Gemma 4: q_norm, k_norm, v_norm per head): eligible,
+#     cancellation is exact for unregularized RMS and epsilon-approximate otherwise.
+#   - MLA models (DeepSeek-V2 family, MiniCPM3): NOT eligible for full cancellation, because
+#     the decoupled RoPE-key slice of the kv_a projection bypasses the latent norm. Use
+#     mla_partial_cancel() instead: it keeps the per-token RMS scalar but applies it only to
+#     the small RoPE slice (and to the query path when there is no q_a_layernorm), which
+#     still removes the norm's weight tensor and the full-width elementwise multiply.
+#   - QK-only-normalized models (e.g. Gemma 3: no v_norm): NOT eligible, the value path
+#     would silently change scale. cancel_pre_attention_norms() refuses unless force=True.
+#
+# Notes:
+#   - These are runtime transforms on an instantiated model (stock modeling code always
+#     executes the division, so the cancellation cannot be expressed in a checkpoint alone).
+#   - Folding is computed in float64 and cast back to the parameter dtype.
+#   - Norm gain conventions: 'plain' multiplies by w (ones-init, e.g. HF Gemma 4, Llama);
+#     'one_plus' multiplies by 1 + w (zeros-init, e.g. HF Gemma 1-3, JAX gemma). The
+#     convention is auto-detected from the weight statistics unless given explicitly.
+
+import torch
+import torch.nn as nn
+
+
+def detect_gain_convention(norm):
+  """Return 'one_plus' if the norm's stored weight looks zeros-initialized, else 'plain'.
+
+  Heuristic: trained plain gains cluster near 1, trained (1+w) offsets cluster near 0.
+  Pass convention='plain' or 'one_plus' explicitly to the fold functions to override."""
+  w = norm.weight.detach().float()
+  return 'one_plus' if w.abs().mean().item() < 0.5 else 'plain'
+
+
+def _effective_gain(norm, convention):
+  if convention == 'auto':
+    convention = detect_gain_convention(norm)
+  g = norm.weight.detach().double()
+  if convention == 'one_plus':
+    g = 1.0 + g
+  return g, convention
+
+
+def fold_norm_into_projs(norm, projs, convention='auto'):
+  """Fold a norm's gain into the following bias-free linear layers (Proposition 1).
+
+  After folding, the norm's stored weight is set to the identity for its convention
+  (ones for 'plain', zeros for 'one_plus'), so the model still computes the same
+  function while the gain lives inside the projection weights."""
+  g, convention = _effective_gain(norm, convention)
+  with torch.no_grad():
+    for p in projs:
+      assert isinstance(p, nn.Linear) and p.bias is None, 'fold requires bias-free nn.Linear'
+      assert p.weight.shape[1] == g.shape[0], 'norm dim does not match projection input dim'
+      p.weight.data = (p.weight.data.double() * g.unsqueeze(0)).to(p.weight.dtype)
+    norm.weight.data = torch.zeros_like(norm.weight) if convention == 'one_plus' \
+        else torch.ones_like(norm.weight)
+  return convention
+
+
+class _RmsScalarKeeper(nn.Module):
+  """Drop-in replacement for a bypassed RMSNorm: passes the input through unchanged but
+  records the per-token scalar s = 1/sqrt(mean(x^2) + eps) for downstream hooks."""
+
+  def __init__(self, eps, keep_scalar=True):
+    super().__init__()
+    self.eps = eps
+    self.keep_scalar = keep_scalar
+    self.s = None
+
+  def forward(self, x):
+    if self.keep_scalar:
+      self.s = torch.rsqrt(x.float().pow(2).mean(-1, keepdim=True) + self.eps).to(x.dtype)
+    return x
+
+
+def _get_norm_eps(norm):
+  eps = getattr(norm, 'eps', None)
+  if eps is None:
+    eps = getattr(norm, 'variance_epsilon', None)
+  assert eps is not None, 'could not read epsilon from norm module'
+  return eps
+
+
+def decoder_layers(model):
+  """Resolve the decoder layer list across common HF model nestings."""
+  for path in ('model.layers', 'model.language_model.layers', 'language_model.model.layers'):
+    obj = model
+    try:
+      for part in path.split('.'):
+        obj = getattr(obj, part)
+      return obj
+    except AttributeError:
+      continue
+  raise AttributeError('could not locate decoder layers; pass them explicitly')
+
+
+def audit_pre_attention_cancellation(model, layers=None):
+  """Per-layer eligibility report for cancelling input_layernorm before attention.
+
+  A layer is eligible if every present q/k/v projection has a matching q/k/v norm.
+  KV-shared layers (projection absent or None) are eligible through the present paths."""
+  layers = decoder_layers(model) if layers is None else layers
+  report = []
+  for i, ly in enumerate(layers):
+    at = ly.self_attn
+    row = {'layer': i}
+    ok = True
+    for name in ('q', 'k', 'v'):
+      proj = getattr(at, f'{name}_proj', None)
+      has_norm = getattr(at, f'{name}_norm', None) is not None
+      row[f'{name}_proj'] = proj is not None
+      row[f'{name}_norm'] = has_norm
+      if proj is not None and not has_norm:
+        ok = False
+    if not any(row[f'{n}_proj'] for n in ('q', 'k', 'v')):
+      ok = False  # nothing to fold into: MLA and other layouts must not pass vacuously
+    row['mla'] = getattr(at, 'kv_a_proj_with_mqa', None) is not None
+    row['eligible'] = ok
+    report.append(row)
+  return report
+
+
+def cancel_pre_attention_norms(model, convention='auto', layers=None, force=False):
+  """Cancel input_layernorm on every eligible decoder layer (Proposition 3).
+
+  Folds the norm gain into the present q/k/v projections, then replaces the norm with a
+  pass-through module. Raises on ineligible layers unless force=True (forcing on an
+  ineligible architecture, e.g. one without a value norm, changes model outputs).
+  Returns the audit report."""
+  layers = decoder_layers(model) if layers is None else layers
+  report = audit_pre_attention_cancellation(model, layers)
+  bad = [r['layer'] for r in report if not r['eligible']]
+  if bad and not force:
+    raise ValueError(f'layers {bad} are not eligible for cancellation (missing q/k/v norm); '
+                     f'use mla_partial_cancel() for MLA models or force=True to override')
+  for ly in layers:
+    at = ly.self_attn
+    if isinstance(ly.input_layernorm, _RmsScalarKeeper):
+      raise ValueError('input_layernorm already cancelled; transforms must be applied once')
+    projs = [p for p in (getattr(at, 'q_proj', None), getattr(at, 'k_proj', None),
+                         getattr(at, 'v_proj', None)) if p is not None]
+    fold_norm_into_projs(ly.input_layernorm, projs, convention)
+    ly.input_layernorm = _RmsScalarKeeper(_get_norm_eps(ly.input_layernorm), keep_scalar=False)
+  return report
+
+
+def mla_partial_cancel(model, convention='auto', layers=None, rope_dims=None):
+  """Partial cancellation for MLA attention (DeepSeek-V2 family, MiniCPM3).
+
+  Folds the input_layernorm gain into the query and kv_a projections, bypasses the
+  full-width normalization multiply, and re-applies the retained per-token RMS scalar
+  only where the eligibility criterion fails: the decoupled RoPE-key slice (the last
+  rope_dims columns of kv_a_proj_with_mqa's output), plus the whole query projection
+  when the model has no q_a_layernorm (e.g. DeepSeek-V2-Lite). The RMS reduction itself
+  is kept; the norm weight tensor and the hidden-width multiply are removed."""
+  layers = decoder_layers(model) if layers is None else layers
+  if rope_dims is None:
+    rope_dims = model.config.qk_rope_head_dim
+  for ly in layers:
+    at = ly.self_attn
+    kv_a = getattr(at, 'kv_a_proj_with_mqa', None)
+    assert kv_a is not None and getattr(at, 'kv_a_layernorm', None) is not None, \
+        'mla_partial_cancel expects kv_a_proj_with_mqa and kv_a_layernorm'
+    if isinstance(ly.input_layernorm, _RmsScalarKeeper):
+      raise ValueError('input_layernorm already cancelled; transforms must be applied once')
+    q_latent = getattr(at, 'q_a_proj', None)
+    q_needs_scalar = q_latent is None or getattr(at, 'q_a_layernorm', None) is None
+    q_in = q_latent if q_latent is not None else getattr(at, 'q_proj', None)
+    assert q_in is not None, 'could not locate the query input projection'
+    fold_norm_into_projs(ly.input_layernorm, [q_in, kv_a], convention)
+    keeper = _RmsScalarKeeper(_get_norm_eps(ly.input_layernorm), keep_scalar=True)
+    ly.input_layernorm = keeper
+
+    def kpe_hook(mod, inp, out, s=keeper, r=rope_dims):
+      out[..., -r:] = out[..., -r:] * s.s
+      return out
+    kv_a.register_forward_hook(kpe_hook)
+    if q_needs_scalar:
+      q_in.register_forward_hook(lambda mod, inp, out, s=keeper: out * s.s)

--- a/flashNorm_cancel_test.py
+++ b/flashNorm_cancel_test.py
@@ -1,0 +1,212 @@
+# Synthetic tests for flashNorm_cancel.py. Runs on CPU in seconds, no model downloads.
+# All math in float64 so the only tolerated error is the epsilon approximation itself.
+#
+# Usage: python flashNorm_cancel_test.py
+
+import copy
+import torch
+import torch.nn as nn
+import flashNorm_cancel as fc
+
+torch.manual_seed(0)
+D = torch.float64
+
+
+class RMS(nn.Module):
+  """Minimal RMSNorm with selectable gain convention; scale=False gives a scale-free norm."""
+
+  def __init__(self, dim, eps=1e-6, convention='plain', scale=True):
+    super().__init__()
+    self.eps = eps
+    self.convention = convention
+    self.scale = scale
+    if scale:
+      init = torch.zeros(dim, dtype=D) if convention == 'one_plus' else torch.ones(dim, dtype=D)
+      self.weight = nn.Parameter(init + 0.1 * torch.randn(dim, dtype=D))
+
+  def forward(self, x):
+    y = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+    if not self.scale:
+      return y
+    g = 1.0 + self.weight if self.convention == 'one_plus' else self.weight
+    return y * g
+
+
+class TinyAttn(nn.Module):
+  """Gemma-4-like attention block: q/k/v projections with per-head norms after each."""
+
+  def __init__(self, n=16, hd=4, eps=1e-6, convention='plain', v_norm=True, kv_shared=False):
+    super().__init__()
+    self.hd = hd
+    self.q_proj = nn.Linear(n, 2 * hd, bias=False, dtype=D)
+    self.q_norm = RMS(hd, eps, convention)
+    if kv_shared:
+      self.k_proj = None
+      self.v_proj = None
+      self.k_norm = None
+      self.v_norm = None
+    else:
+      self.k_proj = nn.Linear(n, hd, bias=False, dtype=D)
+      self.k_norm = RMS(hd, eps, convention)
+      self.v_proj = nn.Linear(n, hd, bias=False, dtype=D)
+      self.v_norm = RMS(hd, eps, convention, scale=False) if v_norm else None
+
+  def per_head(self, norm, y):
+    return norm(y.view(*y.shape[:-1], -1, self.hd)).view(*y.shape)
+
+  def forward(self, x):
+    outs = [self.per_head(self.q_norm, self.q_proj(x))]
+    if self.k_proj is not None:
+      outs.append(self.per_head(self.k_norm, self.k_proj(x)))
+      v = self.v_proj(x)
+      outs.append(self.per_head(self.v_norm, v) if self.v_norm is not None else v)
+    return torch.cat(outs, -1)
+
+
+class TinyLayer(nn.Module):
+  def __init__(self, n=16, eps=1e-6, convention='plain', **kw):
+    super().__init__()
+    self.input_layernorm = RMS(n, eps, convention)
+    self.self_attn = TinyAttn(n, eps=eps, convention=convention, **kw)
+
+  def forward(self, x):
+    return self.self_attn(self.input_layernorm(x))
+
+
+class TinyMLAAttn(nn.Module):
+  """DeepSeek-style MLA block: kv_a splits into a re-normalized latent and a bypassing
+  RoPE-key slice; the query path optionally has its own latent norm (q_lora=False mimics
+  DeepSeek-V2-Lite, whose query path is un-renormalized)."""
+
+  def __init__(self, n=16, kv_lora=8, rope=4, eps=1e-6, q_lora=True):
+    super().__init__()
+    self.rope = rope
+    if q_lora:
+      self.q_a_proj = nn.Linear(n, 8, bias=False, dtype=D)
+      self.q_a_layernorm = RMS(8, eps)
+      self.q_b_proj = nn.Linear(8, 8, bias=False, dtype=D)
+    else:
+      self.q_proj = nn.Linear(n, 8, bias=False, dtype=D)
+    self.kv_a_proj_with_mqa = nn.Linear(n, kv_lora + rope, bias=False, dtype=D)
+    self.kv_a_layernorm = RMS(kv_lora, eps)
+    self.kv_b_proj = nn.Linear(kv_lora, 8, bias=False, dtype=D)
+
+  def forward(self, x):
+    q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x))) if hasattr(self, 'q_a_proj') \
+        else self.q_proj(x)
+    kv = self.kv_a_proj_with_mqa(x)
+    latent, k_pe = kv[..., :-self.rope], kv[..., -self.rope:]
+    return torch.cat([q, self.kv_b_proj(self.kv_a_layernorm(latent)), k_pe], -1)
+
+
+class TinyMLALayer(nn.Module):
+  def __init__(self, eps=1e-6, q_lora=True):
+    super().__init__()
+    self.input_layernorm = RMS(16, eps)
+    self.self_attn = TinyMLAAttn(eps=eps, q_lora=q_lora)
+
+  def forward(self, x):
+    return self.self_attn(self.input_layernorm(x))
+
+
+def max_rel(a, b):
+  return ((a - b).abs().max() / b.abs().max()).item()
+
+
+def check(name, err, tol):
+  status = 'PASS' if err <= tol else 'FAIL'
+  print(f'{status}  {name}: max rel err {err:.3e} (tol {tol:.0e})')
+  assert err <= tol, name
+
+
+def main():
+  x = torch.randn(3, 5, 16, dtype=D)
+
+  # 1. eligible Gemma-4-like layer: cancellation matches the reference within epsilon effects
+  for eps, tol in ((0.0, 1e-12), (1e-6, 5e-5)):
+    ref = TinyLayer(eps=eps).double()
+    out_ref = ref(x)
+    m = copy.deepcopy(ref)
+    report = fc.cancel_pre_attention_norms(None, convention='plain', layers=[m])
+    assert all(r['eligible'] for r in report)
+    check(f'gemma4-like cancel, eps={eps}', max_rel(m(x), out_ref), tol)
+
+  # 2. KV-shared layer (no k/v projections): still eligible, q path only
+  ref = TinyLayer(kv_shared=True).double()
+  out_ref = ref(x)
+  m = copy.deepcopy(ref)
+  fc.cancel_pre_attention_norms(None, convention='plain', layers=[m])
+  check('kv-shared cancel', max_rel(m(x), out_ref), 5e-5)
+
+  # 3. one_plus gain convention: auto-detected and folded correctly (exact at eps=0)
+  for eps, tol in ((0.0, 1e-12), (1e-6, 5e-5)):
+    ref = TinyLayer(convention='one_plus', eps=eps).double()
+    assert fc.detect_gain_convention(ref.input_layernorm) == 'one_plus'
+    out_ref = ref(x)
+    m = copy.deepcopy(ref)
+    fc.cancel_pre_attention_norms(None, convention='auto', layers=[m])
+    check(f'one_plus convention cancel, eps={eps}', max_rel(m(x), out_ref), tol)
+
+  # 4. negative control: Gemma-3-like (no v_norm) must refuse, and forcing must change outputs
+  ref = TinyLayer(v_norm=False).double()
+  m = copy.deepcopy(ref)
+  try:
+    fc.cancel_pre_attention_norms(None, convention='plain', layers=[m])
+    raise AssertionError('ineligible layer was not refused')
+  except ValueError:
+    print('PASS  ineligible layer refused without force=True')
+  m = copy.deepcopy(ref)
+  fc.cancel_pre_attention_norms(None, convention='plain', layers=[m], force=True)
+  err = max_rel(m(3.0 * x), ref(3.0 * x))
+  print(f'PASS  forced ineligible cancel diverges as expected: max rel err {err:.3e}')
+  assert err > 1e-3, 'forced cancel on ineligible layer should change outputs'
+
+  # 4b. MLA layer must be refused by full cancellation (audit must not pass vacuously)
+  try:
+    fc.cancel_pre_attention_norms(None, convention='plain', layers=[TinyMLALayer().double()])
+    raise AssertionError('MLA layer was not refused by cancel_pre_attention_norms')
+  except ValueError:
+    print('PASS  MLA layer refused by full cancellation')
+
+  # 4c. fold-only with the norm still executing: identity weight must be correct per convention
+  for conv in ('plain', 'one_plus'):
+    ref = TinyLayer(convention=conv).double()
+    out_ref = ref(x)
+    m = copy.deepcopy(ref)
+    fc.fold_norm_into_projs(m.input_layernorm,
+                            [m.self_attn.q_proj, m.self_attn.k_proj, m.self_attn.v_proj],
+                            convention=conv)
+    check(f'fold-only, norm live, {conv}', max_rel(m(x), out_ref), 1e-12)
+
+  # 4d. two-layer cancel: hook/closure binding must stay per-layer
+  refs = [TinyLayer().double() for _ in range(2)]
+  outs = [r(x) for r in refs]
+  ms = [copy.deepcopy(r) for r in refs]
+  fc.cancel_pre_attention_norms(None, convention='plain', layers=ms)
+  for i in range(2):
+    check(f'two-layer cancel, layer {i}', max_rel(ms[i](x), outs[i]), 5e-5)
+
+  # 5. MLA partial cancellation: matches reference within epsilon effects; naive bypass diverges
+  for q_lora, tag in ((True, 'deepseek-v2-like'), (False, 'v2-lite-like (bare query path)')):
+    ref = TinyMLALayer(q_lora=q_lora).double()
+    out_ref = ref(x)
+    m = copy.deepcopy(ref)
+    fc.mla_partial_cancel(None, convention='plain', layers=[m], rope_dims=4)
+    check(f'mla partial cancel, {tag}', max_rel(m(x), out_ref), 5e-5)
+    x2 = torch.randn(3, 5, 16, dtype=D)  # fresh input: catches a keeper caching stale s
+    check(f'mla partial cancel, {tag}, second forward on fresh input',
+          max_rel(m(x2), ref(x2)), 5e-5)
+    naive = copy.deepcopy(ref)
+    fc.fold_norm_into_projs(naive.input_layernorm,
+                            [naive.self_attn.q_a_proj if q_lora else naive.self_attn.q_proj,
+                             naive.self_attn.kv_a_proj_with_mqa], convention='plain')
+    naive.input_layernorm = fc._RmsScalarKeeper(1e-6, keep_scalar=False)
+    err = max_rel(naive(3.0 * x), ref(3.0 * x))
+    print(f'PASS  naive MLA bypass diverges as expected ({tag}): max rel err {err:.3e}')
+    assert err > 1e-3, 'naive MLA bypass should change outputs'
+
+  print('\nall tests passed')
+
+
+if __name__ == '__main__':
+  main()

--- a/flashNorm_cancel_test.py
+++ b/flashNorm_cancel_test.py
@@ -191,7 +191,8 @@ def main():
     ref = TinyMLALayer(q_lora=q_lora).double()
     out_ref = ref(x)
     m = copy.deepcopy(ref)
-    fc.mla_partial_cancel(None, convention='plain', layers=[m], rope_dims=4)
+    rep = fc.mla_partial_cancel(None, convention='plain', layers=[m], rope_dims=4)
+    assert rep[0]['q_scalar_hook'] == (not q_lora) and rep[0]['rope_slice_scalar'] == 4
     check(f'mla partial cancel, {tag}', max_rel(m(x), out_ref), 5e-5)
     x2 = torch.randn(3, 5, 16, dtype=D)  # fresh input: catches a keeper caching stale s
     check(f'mla partial cancel, {tag}, second forward on fresh input',
@@ -200,7 +201,7 @@ def main():
     fc.fold_norm_into_projs(naive.input_layernorm,
                             [naive.self_attn.q_a_proj if q_lora else naive.self_attn.q_proj,
                              naive.self_attn.kv_a_proj_with_mqa], convention='plain')
-    naive.input_layernorm = fc._RmsScalarKeeper(1e-6, keep_scalar=False)
+    naive.input_layernorm = fc._BypassedNorm(1e-6, keep_scalar=False)
     err = max_rel(naive(3.0 * x), ref(3.0 * x))
     print(f'PASS  naive MLA bypass diverges as expected ({tag}): max rel err {err:.3e}')
     assert err > 1e-3, 'naive MLA bypass should change outputs'


### PR DESCRIPTION
Adds Proposition 3 of the FlashNorm paper (norm cancellation) as a runtime transform module, with an eligibility audit that prevents applying it where it silently breaks models.

## What

An RMSNorm followed by a bias-free linear followed by another RMSNorm makes the first norm redundant: fold its gain into the linear (Prop 1), and scale invariance of the second norm cancels the division. New module `flashNorm_cancel.py`:

- `audit_pre_attention_cancellation(model)`: per-layer eligibility report. A layer is eligible only if every present q/k/v projection is re-normalized downstream; layers with nothing to fold into (e.g. MLA layouts) are never eligible.
- `cancel_pre_attention_norms(model)`: folds the input_layernorm gain into q/k/v projections and removes the division on eligible layers; refuses ineligible ones unless `force=True`. Handles KV-shared layers (absent or None projections) and both norm gain conventions: plain `w` (HF Gemma 4, Llama) and `1+w` (HF Gemma 1-3, JAX gemma), auto-detected.
- `mla_partial_cancel(model)`: the correct variant for MLA models (DeepSeek-V2 family, MiniCPM3), where the decoupled RoPE-key slice bypasses the latent norm and full cancellation is invalid. Keeps the per-token RMS scalar but applies it only to the small RoPE slice (and the query path when there is no `q_a_layernorm`, as in DeepSeek-V2-Lite), still removing the norm weights and the full-width multiply.

## Validation

- `flashNorm_cancel_test.py`: 18 synthetic float64 checks on CPU (seconds, no downloads): exactness at eps=0 (~1e-16), epsilon-level agreement at eps=1e-6, both gain conventions, KV-shared layers, multi-layer hook binding, fresh-input scalar recomputation, and negative controls proving the eligibility criterion is load-bearing (forced cancellation on ineligible layouts diverges by ~2x relative error; MLA layouts are refused).
- Checkpoint validation on real models (fp32, wikitext + greedy decode): Gemma-4-E2B cancellation gives max logit deviation 6.8e-4 versus 5.6e-4 for the mathematically exact fold-only control, perplexity +0.0006%, identical greedy continuations; Gemma-4-12B shows the same pattern (0.023 vs 0.089 control). MiniCPM3-4B and DeepSeek-V2-Lite validate the MLA partial variant (equivalent within rounding), while naive full deletion on MLA catastrophically breaks the model (V2-Lite perplexity 7.5 to 618), which is exactly what the eligibility audit exists to prevent.

## Notes

- Runtime transform on a loaded model: stock modeling code always executes the division, so the cancellation cannot be expressed in a checkpoint alone.
- Not yet included in the PyPI wheel (README says so); packaging can follow in a separate change if wanted.
- Possible follow-ups: notebook version, publishing a cancelled Gemma-4 checkpoint variant, wiring the audit into `flashify_repo`.
