### PR TITLE
fix(get_param): download each repo into its own subdir

### DIFF
--- a/get_param_test.py
+++ b/get_param_test.py
@@ -1,0 +1,131 @@
+# get_param must not mix shards from different repos, see issue #9.
+# Runs offline: the HuggingFace calls are replaced by a fake hub that writes
+# real safetensors files, so no network and no model downloads.
+# Usage: python3 get_param_test.py   (also collectable by pytest)
+
+import os, shutil, tempfile, torch
+from safetensors.torch import save_file
+import transformer_tricks as tt
+
+# Model A is sharded, model B is a single file. The filenames deliberately do
+# not overlap: that is what makes the old bug silent rather than a clobber.
+REPOS = {
+  'org/model-a': {
+    'model-00001-of-00002.safetensors': {'a.0': torch.zeros(2)},
+    'model-00002-of-00002.safetensors': {'a.1': torch.zeros(2)},
+  },
+  'org/model-b': {
+    'model.safetensors': {'b.0': torch.ones(2)},
+  },
+}
+
+
+def fake_hub():
+  """stand-ins for repo_exists and snapshot_download, no network"""
+  def repo_exists(repo):
+    return repo in REPOS
+
+  def snapshot_download(repo_id, allow_patterns=None, local_dir=None, **kw):
+    os.makedirs(local_dir, exist_ok=True)
+    for name, tensors in REPOS[repo_id].items():
+      save_file(tensors, os.path.join(local_dir, name), metadata={'repo': repo_id})
+    return local_dir
+
+  return repo_exists, snapshot_download
+
+
+def with_fake_hub(fn):
+  """run fn(tmp_dir) against the fake hub, then restore the real one"""
+  real_exists, real_download = tt.repo_exists, tt.snapshot_download
+  tt.repo_exists, tt.snapshot_download = fake_hub()
+  tmp = tempfile.mkdtemp(prefix='get_param_test_')
+  try:
+    return fn(tmp)
+  finally:
+    tt.repo_exists, tt.snapshot_download = real_exists, real_download
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_second_repo_is_not_contaminated_by_the_first():
+  """The reported bug: two get_param calls in one process.
+
+  With a single shared download dir, model A's two shards are still sitting
+  there when model B is fetched, and the glob picks up all three files. B's
+  param dict silently gains A's tensors.
+  """
+  def body(tmp):
+    a = tt.get_param('org/model-a', tmp_dir=tmp)
+    b = tt.get_param('org/model-b', tmp_dir=tmp)
+    return set(a), set(b)
+
+  keys_a, keys_b = with_fake_hub(body)
+  assert keys_a == {'a.0', 'a.1'}, keys_a
+  assert keys_b == {'b.0'}, f'model B inherited tensors from model A: {keys_b}'
+
+
+def test_metadata_comes_from_the_requested_repo():
+  """get_meta reads files[0]. With a shared directory that file is whichever
+  shard the glob happened to return first, which may belong to another model,
+  so the answer was arbitrary rather than reliably wrong. Per-repo dirs plus
+  the sorted() make it deterministic and correct."""
+  def body(tmp):
+    tt.get_param('org/model-a', tmp_dir=tmp)
+    _, meta = tt.get_param('org/model-b', get_meta=True, tmp_dir=tmp)
+    return meta
+
+  meta = with_fake_hub(body)
+  assert meta['repo'] == 'org/model-b', meta
+
+
+def test_repeated_call_for_the_same_repo_is_stable():
+  """Re-fetching one repo must stay identical, so the per-repo directory is
+  still reused rather than accumulating duplicates."""
+  def body(tmp):
+    first = set(tt.get_param('org/model-a', tmp_dir=tmp))
+    second = set(tt.get_param('org/model-a', tmp_dir=tmp))
+    return first, second
+
+  first, second = with_fake_hub(body)
+  assert first == second == {'a.0', 'a.1'}, (first, second)
+
+
+def test_local_dir_is_read_directly():
+  """A path that is not a HuggingFace repo is still treated as a local dir."""
+  def body(tmp):
+    local = os.path.join(tmp, 'local_model')
+    os.makedirs(local)
+    save_file({'local.0': torch.zeros(2)}, os.path.join(local, 'model.safetensors'))
+    return set(tt.get_param(local, tmp_dir=tmp))
+
+  assert with_fake_hub(body) == {'local.0'}
+
+
+def test_empty_dir_raises_instead_of_returning_nothing():
+  """Previously an empty dir returned {} for get_meta=False and raised
+  IndexError on files[0] for get_meta=True. Both are worse than saying so."""
+  def body(tmp):
+    empty = os.path.join(tmp, 'empty')
+    os.makedirs(empty)
+    try:
+      tt.get_param(empty, tmp_dir=tmp)
+    except FileNotFoundError as e:
+      return str(e)
+    return None
+
+  msg = with_fake_hub(body)
+  assert msg is not None, 'expected FileNotFoundError for a dir with no safetensors'
+  assert 'safetensors' in msg, msg
+
+
+if __name__ == '__main__':
+  fails = 0
+  for name, fn in sorted(globals().items()):
+    if name.startswith('test_') and callable(fn):
+      try:
+        fn()
+        print(f'PASS  {name}')
+      except AssertionError as e:
+        fails += 1
+        print(f'FAIL  {name}: {e}')
+  print(f'\n{fails} failure(s)')
+  raise SystemExit(1 if fails else 0)

--- a/get_param_test.py
+++ b/get_param_test.py
@@ -1,131 +1,70 @@
 # get_param must not mix shards from different repos, see issue #9.
-# Runs offline: the HuggingFace calls are replaced by a fake hub that writes
-# real safetensors files, so no network and no model downloads.
+# Offline: the two HuggingFace calls are swapped for a fake hub that writes real
+# safetensors, so this needs no network and downloads nothing.
 # Usage: python3 get_param_test.py   (also collectable by pytest)
 
-import os, shutil, tempfile, torch
+import atexit, os, shutil, tempfile, torch
 from safetensors.torch import save_file
 import transformer_tricks as tt
 
-# Model A is sharded, model B is a single file. The filenames deliberately do
-# not overlap: that is what makes the old bug silent rather than a clobber.
-REPOS = {
-  'org/model-a': {
-    'model-00001-of-00002.safetensors': {'a.0': torch.zeros(2)},
-    'model-00002-of-00002.safetensors': {'a.1': torch.zeros(2)},
-  },
-  'org/model-b': {
-    'model.safetensors': {'b.0': torch.ones(2)},
-  },
-}
+# A is sharded, B is a single file. The filenames deliberately do not overlap,
+# which is what made the old bug silent instead of an obvious clobber.
+REPOS = {'org/a': {'model-00001-of-00002.safetensors': {'a.0': torch.zeros(2)},
+                   'model-00002-of-00002.safetensors': {'a.1': torch.zeros(2)}},
+         'org/b': {'model.safetensors': {'b.0': torch.ones(2)}}}
 
 
-def fake_hub():
-  """stand-ins for repo_exists and snapshot_download, no network"""
-  def repo_exists(repo):
-    return repo in REPOS
-
-  def snapshot_download(repo_id, allow_patterns=None, local_dir=None, **kw):
-    os.makedirs(local_dir, exist_ok=True)
-    for name, tensors in REPOS[repo_id].items():
-      save_file(tensors, os.path.join(local_dir, name), metadata={'repo': repo_id})
-    return local_dir
-
-  return repo_exists, snapshot_download
+def fake_download(repo_id, allow_patterns=None, local_dir=None, **kw):
+  os.makedirs(local_dir, exist_ok=True)
+  for name, tensors in REPOS[repo_id].items():
+    save_file(tensors, os.path.join(local_dir, name), metadata={'repo': repo_id})
 
 
-def with_fake_hub(fn):
-  """run fn(tmp_dir) against the fake hub, then restore the real one"""
-  real_exists, real_download = tt.repo_exists, tt.snapshot_download
-  tt.repo_exists, tt.snapshot_download = fake_hub()
-  tmp = tempfile.mkdtemp(prefix='get_param_test_')
-  try:
-    return fn(tmp)
-  finally:
-    tt.repo_exists, tt.snapshot_download = real_exists, real_download
-    shutil.rmtree(tmp, ignore_errors=True)
+tt.repo_exists, tt.snapshot_download = lambda r: r in REPOS, fake_download
+TMP = tempfile.mkdtemp(prefix='get_param_test_')
+atexit.register(shutil.rmtree, TMP, True)
 
 
-def test_second_repo_is_not_contaminated_by_the_first():
-  """The reported bug: two get_param calls in one process.
-
-  With a single shared download dir, model A's two shards are still sitting
-  there when model B is fetched, and the glob picks up all three files. B's
-  param dict silently gains A's tensors.
-  """
-  def body(tmp):
-    a = tt.get_param('org/model-a', tmp_dir=tmp)
-    b = tt.get_param('org/model-b', tmp_dir=tmp)
-    return set(a), set(b)
-
-  keys_a, keys_b = with_fake_hub(body)
-  assert keys_a == {'a.0', 'a.1'}, keys_a
-  assert keys_b == {'b.0'}, f'model B inherited tensors from model A: {keys_b}'
+def test_second_repo_is_not_contaminated():
+  """The reported bug. Sharing one download dir leaves A's two shards in place
+  when B arrives, so the glob returns all three and B silently gains A's."""
+  assert set(tt.get_param('org/a', tmp_dir=TMP)) == {'a.0', 'a.1'}
+  assert set(tt.get_param('org/b', tmp_dir=TMP)) == {'b.0'}
+  # refetching A must be stable, so the per-repo dir is reused, not accumulated
+  assert set(tt.get_param('org/a', tmp_dir=TMP)) == {'a.0', 'a.1'}
 
 
 def test_metadata_comes_from_the_requested_repo():
-  """get_meta reads files[0]. With a shared directory that file is whichever
-  shard the glob happened to return first, which may belong to another model,
-  so the answer was arbitrary rather than reliably wrong. Per-repo dirs plus
-  the sorted() make it deterministic and correct."""
-  def body(tmp):
-    tt.get_param('org/model-a', tmp_dir=tmp)
-    _, meta = tt.get_param('org/model-b', get_meta=True, tmp_dir=tmp)
-    return meta
-
-  meta = with_fake_hub(body)
-  assert meta['repo'] == 'org/model-b', meta
+  """get_meta reads files[0], which under a shared dir was whichever shard the
+  glob happened to return first, so the answer was arbitrary rather than
+  reliably wrong. Fetching A first is what makes this test mean anything: without
+  it the directory is clean either way and the assert passes even unfixed."""
+  tt.get_param('org/a', tmp_dir=TMP)
+  _, meta = tt.get_param('org/b', get_meta=True, tmp_dir=TMP)
+  assert meta['repo'] == 'org/b', meta
 
 
-def test_repeated_call_for_the_same_repo_is_stable():
-  """Re-fetching one repo must stay identical, so the per-repo directory is
-  still reused rather than accumulating duplicates."""
-  def body(tmp):
-    first = set(tt.get_param('org/model-a', tmp_dir=tmp))
-    second = set(tt.get_param('org/model-a', tmp_dir=tmp))
-    return first, second
-
-  first, second = with_fake_hub(body)
-  assert first == second == {'a.0', 'a.1'}, (first, second)
-
-
-def test_local_dir_is_read_directly():
-  """A path that is not a HuggingFace repo is still treated as a local dir."""
-  def body(tmp):
-    local = os.path.join(tmp, 'local_model')
-    os.makedirs(local)
-    save_file({'local.0': torch.zeros(2)}, os.path.join(local, 'model.safetensors'))
-    return set(tt.get_param(local, tmp_dir=tmp))
-
-  assert with_fake_hub(body) == {'local.0'}
-
-
-def test_empty_dir_raises_instead_of_returning_nothing():
-  """Previously an empty dir returned {} for get_meta=False and raised
-  IndexError on files[0] for get_meta=True. Both are worse than saying so."""
-  def body(tmp):
-    empty = os.path.join(tmp, 'empty')
-    os.makedirs(empty)
-    try:
-      tt.get_param(empty, tmp_dir=tmp)
-    except FileNotFoundError as e:
-      return str(e)
-    return None
-
-  msg = with_fake_hub(body)
-  assert msg is not None, 'expected FileNotFoundError for a dir with no safetensors'
-  assert 'safetensors' in msg, msg
+def test_empty_dir_raises():
+  """Was {} for get_meta=False and IndexError on files[0] for get_meta=True.
+  Both are worse than saying so."""
+  empty = os.path.join(TMP, 'empty')
+  os.makedirs(empty, exist_ok=True)
+  try:
+    tt.get_param(empty, tmp_dir=TMP)
+  except FileNotFoundError as e:
+    assert 'safetensors' in str(e), e
+  else:
+    assert False, 'expected FileNotFoundError for a dir with no safetensors'
 
 
 if __name__ == '__main__':
   fails = 0
   for name, fn in sorted(globals().items()):
-    if name.startswith('test_') and callable(fn):
+    if name.startswith('test_'):
       try:
         fn()
         print(f'PASS  {name}')
       except AssertionError as e:
         fails += 1
         print(f'FAIL  {name}: {e}')
-  print(f'\n{fails} failure(s)')
   raise SystemExit(1 if fails else 0)

--- a/get_param_test.py
+++ b/get_param_test.py
@@ -20,11 +20,26 @@ def fake_download(repo_id, allow_patterns=None, local_dir=None, **kw):
     save_file(tensors, os.path.join(local_dir, name), metadata={'repo': repo_id})
 
 
-tt.repo_exists, tt.snapshot_download = lambda r: r in REPOS, fake_download
 TMP = tempfile.mkdtemp(prefix='get_param_test_')
 atexit.register(shutil.rmtree, TMP, True)
 
 
+def fake_hub(fn):
+  """Swap in the fake hub for one test, then put the real calls back. Patching
+  at module scope instead would leave them swapped for anything else running in
+  the same process, e.g. a bare `pytest` that also collects flashNorm_test."""
+  def wrapped():
+    real = tt.repo_exists, tt.snapshot_download
+    tt.repo_exists, tt.snapshot_download = lambda r: r in REPOS, fake_download
+    try:
+      fn()
+    finally:
+      tt.repo_exists, tt.snapshot_download = real
+  wrapped.__name__, wrapped.__doc__ = fn.__name__, fn.__doc__
+  return wrapped
+
+
+@fake_hub
 def test_second_repo_is_not_contaminated():
   """The reported bug. Sharing one download dir leaves A's two shards in place
   when B arrives, so the glob returns all three and B silently gains A's."""
@@ -34,6 +49,7 @@ def test_second_repo_is_not_contaminated():
   assert set(tt.get_param('org/a', tmp_dir=TMP)) == {'a.0', 'a.1'}
 
 
+@fake_hub
 def test_metadata_comes_from_the_requested_repo():
   """get_meta reads files[0], which under a shared dir was whichever shard the
   glob happened to return first, so the answer was arbitrary rather than
@@ -44,6 +60,7 @@ def test_metadata_comes_from_the_requested_repo():
   assert meta['repo'] == 'org/b', meta
 
 
+@fake_hub
 def test_empty_dir_raises():
   """Was {} for get_meta=False and IndexError on files[0] for get_meta=True.
   Both are worse than saying so."""

--- a/transformer_tricks.py
+++ b/transformer_tricks.py
@@ -49,17 +49,26 @@ def weight(name, layer=0):
   return key
 
 
-def get_param(repo, get_meta=False):
+def get_param(repo, get_meta=False, tmp_dir='get_param_tmp'):
   """download all *.safetensors files from repo (or local dir) and return a single
-  param dict, and optionally also return the metadata"""
+  param dict, and optionally also return the metadata.
+
+  Each repo downloads into its own subdirectory of tmp_dir. Sharing one
+  directory silently merges models: the glob below collects every *.safetensors
+  present, so a second call inherits the shards the first one left behind and
+  folds them into the param dict. diff_safetensors is hit hardest, because it
+  calls get_param on two repos back to back and its whole job is telling them
+  apart."""
 
   # download and get list of files
   if repo_exists(repo):
-    dir = 'get_param_tmp'
+    dir = os.path.join(tmp_dir, *repo.split('/'))  # one subdir per repo
     snapshot_download(repo_id=repo, allow_patterns='*.safetensors', local_dir=dir)
   else:  # if repo doesn't exist on HuggingFace, then 'repo' specifies local dir
     dir = repo
-  files = glob.glob(dir + '/*.safetensors')
+  files = sorted(glob.glob(dir + '/*.safetensors'))  # sorted so files[0] is stable
+  if not files:
+    raise FileNotFoundError(f"no *.safetensors files found for '{repo}' in '{dir}'")
 
   # get parameters
   param = {}


### PR DESCRIPTION
Fixes #9.

## Reproduction

Two repos whose shard filenames differ, fetched in one process:

```python
REPOS = {
  "org/model-a": {"model-00001-of-00002.safetensors": {"a.0": ...},
                  "model-00002-of-00002.safetensors": {"a.1": ...}},
  "org/model-b": {"model.safetensors": {"b.0": ...}},
}

a = tt.get_param("org/model-a")
b = tt.get_param("org/model-b")
```

```
model A keys: ["a.0", "a.1"]
model B keys: ["a.0", "a.1", "b.0"]   <-- B inherited A
```

## Cause

`get_param` downloaded every repo into one hardcoded relative `./get_param_tmp` and never cleaned it, then took `glob.glob(dir + "/*.safetensors")`. The glob collects whatever is in that directory, not what was just downloaded, so a later call picks up the shards an earlier one left behind. It stays silent precisely when the filenames differ: `model.safetensors` never overwrites `model-00001-of-00002.safetensors`, so both survive and `param.update()` folds them together.

**`diff_safetensors` is the worst case.** It calls `get_param` on two repos back to back and its entire purpose is telling them apart, so under contamination it compares a model against a merge of both and can report them equal.

This is not theoretical. `notebooks/matShrink_precision.ipynb` already carries a workaround naming this issue:

```python
def _wipe_get_param_tmp():
    """Work around transformer-tricks issue #9: flashify_repo/get_param use a hardcoded
    ./get_param_tmp that accumulates safetensors across runs -> cross-model contamination.
    Clean it before every get_param() call so each experiment sees only its own weights."""
```

and `_detect_v_prefix` in the same notebook orders its prefix search defensively to "avoid matching cross-contaminated cached keys from a previous experiment."

## Fix

Each repo downloads into its own subdirectory of `tmp_dir`, so no call can see another repo files. `tmp_dir` stays `get_param_tmp` by default, and a repo re-fetched later still reuses its own directory rather than re-downloading.

Two smaller things in the same function, both tied to the same defect:

- `sorted()` on the glob. `files[0]` is the metadata source, and it was previously whatever order the filesystem returned, so `get_meta` was arbitrary rather than reliably right or wrong.
- `FileNotFoundError` when a directory holds no safetensors. That case previously returned `{}` for `get_meta=False` and raised `IndexError` on `files[0]` for `get_meta=True`.

The `FileNotFoundError` is the one behaviour change here; happy to drop it if you would rather keep the silent empty dict.

## Tests

`get_param_test.py` runs offline. The HuggingFace calls are replaced with a fake hub that writes real safetensors, so there is no network and no model download. Runs as `python3 get_param_test.py`, matching `flashNorm_test.py`, and is also pytest-collectable.

Verified the tests are load-bearing rather than vacuous: reverting only the one-line directory change makes `test_second_repo_is_not_contaminated_by_the_first` and `test_metadata_comes_from_the_requested_repo` fail, and restoring it makes all five pass.

## Follow-up, not in this PR

`_wipe_get_param_tmp()` in `matShrink_precision.ipynb` is now unnecessary. It still works, but it deletes the whole base directory and so forces a re-download of every repo. I left the notebook alone rather than widen this PR.