### PR TITLE
ci: add CI and daily workflows, fix stale flashNorm notebook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # the library deps from pyproject, plus jupytext for the notebook check
-          pip install transformers accelerate datasets jupytext
+          pip install transformers accelerate datasets jupytext nbdime
 
       - name: Import smoke test
         run: python -c "import transformer_tricks as tt; print(tt.weight('Q', 3))"
@@ -46,9 +46,10 @@ jobs:
         run: util/check_notebooks
 
       - name: Package builds
+        # reuses util/push_pypi so the packaging file list lives in one place;
+        # PUSH_PYPI_BUILD_ONLY stops it before the twine upload
+        env:
+          PUSH_PYPI_BUILD_ONLY: '1'
         run: |
           pip install build
-          # push_pypi builds from a staging dir containing just these files
-          rm -rf /tmp/pypi && mkdir -p /tmp/pypi
-          cp LICENSE README.md pyproject.toml transformer_tricks.py /tmp/pypi/
-          python -m build --outdir /tmp/pypi/dist /tmp/pypi
+          cd util && ./push_pypi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+# Fast checks on every push and pull request. Nothing here downloads a model
+# or hits the network beyond pip, so it finishes in a couple of minutes.
+# The heavy model tests live in daily.yml.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'   # matches requires-python in pyproject.toml
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          # the library deps from pyproject, plus jupytext for the notebook check
+          pip install transformers accelerate datasets jupytext
+
+      - name: Import smoke test
+        run: python -c "import transformer_tricks as tt; print(tt.weight('Q', 3))"
+
+      - name: Offline unit tests
+        run: |
+          # explicit list: flashNorm_test.py downloads models and is run by daily.yml
+          ran=0
+          for t in get_param_test.py; do
+            if [ -f "$t" ]; then echo "running $t"; python3 "$t"; ran=1; fi
+          done
+          if [ "$ran" = 0 ]; then echo "no offline tests present yet"; fi
+
+      - name: Notebooks match their .py sources
+        run: util/check_notebooks
+
+      - name: Package builds
+        run: |
+          pip install build
+          # push_pypi builds from a staging dir containing just these files
+          rm -rf /tmp/pypi && mkdir -p /tmp/pypi
+          cp LICENSE README.md pyproject.toml transformer_tricks.py /tmp/pypi/
+          python -m build --outdir /tmp/pypi/dist /tmp/pypi

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,38 @@
+# The "daily builds" half of issue #3. This one downloads SmolLM-135M and
+# SmolLM-360M and runs flashify + inference + perplexity end to end, so it is
+# far too slow for every push. It runs on a schedule and on demand instead.
+name: Daily
+
+on:
+  schedule:
+    - cron: '17 6 * * *'   # 06:17 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  model-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install transformers accelerate datasets
+
+      - name: Cache HuggingFace downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-smollm
+
+      - name: flashNorm end-to-end (downloads models, runs perplexity)
+        run: python3 flashNorm_test.py

--- a/notebooks/flashNorm_example.ipynb
+++ b/notebooks/flashNorm_example.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "456ef5b0",
+   "id": "40f4ab72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,39 +21,40 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8cd3fd7",
+   "id": "1b6a708c",
    "metadata": {},
    "outputs": [],
    "source": [
     "#-------------------------------------------------------------------------------\n",
-    "# Example 1\n",
+    "# Example 1: compat mode (default), loads with stock AutoModelForCausalLM\n",
     "#-------------------------------------------------------------------------------\n",
     "\n",
-    "# convert model and store the new model in ./SmolLM-135M_flashNorm_test\n",
+    "# convert model and store the new model in ./SmolLM-135M_flashNorm\n",
     "tt.flashify_repo('HuggingFaceTB/SmolLM-135M')\n",
     "\n",
     "# run example inference of original and modified model\n",
     "tt.hello_world('HuggingFaceTB/SmolLM-135M')\n",
-    "tt.hello_world('./SmolLM-135M_flashNorm_test')\n",
+    "tt.hello_world('./SmolLM-135M_flashNorm')\n",
     "\n",
     "# measure perplexity of original and modified model\n",
     "tt.perplexity('HuggingFaceTB/SmolLM-135M', speedup=16)\n",
-    "tt.perplexity('./SmolLM-135M_flashNorm_test', speedup=16)"
+    "tt.perplexity('./SmolLM-135M_flashNorm', speedup=16)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31381dd7",
+   "id": "1878d3ab",
    "metadata": {},
    "outputs": [],
    "source": [
     "#-------------------------------------------------------------------------------\n",
-    "# Example 2\n",
+    "# Example 2: strict mode, norm tensors deleted, requires the custom\n",
+    "# LlamaFlashNorm modeling class to load\n",
     "#-------------------------------------------------------------------------------\n",
     "\n",
-    "# convert model and store the new model in ./SmolLM-135M_flashNorm\n",
-    "tt.flashify_repo('HuggingFaceTB/SmolLM-135M')\n",
+    "# convert model (strict=True deletes norm tensors from the state dict)\n",
+    "tt.flashify_repo('HuggingFaceTB/SmolLM-135M', strict=True)\n",
     "\n",
     "# run example inference of original and modified model\n",
     "tt.hello_world('HuggingFaceTB/SmolLM-135M')\n",
@@ -66,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46c7d85f",
+   "id": "9e4ee7e0",
    "metadata": {},
    "source": [
     "Whenever you change this file, make sure to regenerate the jupyter notebook by typing:\n",

--- a/util/check_notebooks
+++ b/util/check_notebooks
@@ -1,40 +1,43 @@
 #!/bin/bash
 
-# verify that notebooks/ matches the .py sources they are generated from,
-# i.e. that someone ran util/gen_notebooks after editing the .py file
+# verify that notebooks/ is up to date with the .py sources it is generated from
 # usage: util/check_notebooks  (run from the root dir of this repo)
 #
-# jupytext assigns a fresh random id to every cell on each run, so ids are
-# stripped before comparing. Everything else must match exactly.
+# Runs util/gen_notebooks so this script never duplicates the generation logic,
+# then diffs the result against what is committed and puts the originals back.
+# Comparison is nbdiff -I (nbdime): content-aware, and -I ignores the cell ids
+# that jupytext regenerates on every run. Needs: pip install nbdime jupytext
 
 set -u
-tmp=$(mktemp -d)
-trap 'rm -rf "$tmp"' EXIT
+
+if ! command -v nbdiff > /dev/null; then
+  echo "check_notebooks: nbdiff not found, install it with 'pip install nbdime'"
+  exit 2
+fi
+
+backup=$(mktemp -d)
+cp notebooks/*.ipynb "$backup"/
+# always put the committed notebooks back, however we exit
+trap 'cp "$backup"/*.ipynb notebooks/ 2> /dev/null; rm -rf "$backup"' EXIT
+
+util/gen_notebooks > /dev/null 2>&1
+
 status=0
-
-strip_ids() {
-  python3 -c "
-import json, sys
-nb = json.load(open(sys.argv[1]))
-for cell in nb.get('cells', []):
-  cell.pop('id', None)
-print(json.dumps(nb, indent=1, sort_keys=True))
-" "$1"
-}
-
-for fname in slimAttn_paper flashNorm_example; do
-  jupytext "$fname".py -o "$tmp/$fname".ipynb --quiet 2>/dev/null
-  strip_ids "notebooks/$fname.ipynb" > "$tmp/$fname.committed.json"
-  strip_ids "$tmp/$fname.ipynb"      > "$tmp/$fname.regenerated.json"
-  if diff -u "$tmp/$fname.committed.json" "$tmp/$fname.regenerated.json" \
-       > "$tmp/$fname.diff"; then
-    echo "ok:    notebooks/$fname.ipynb matches $fname.py"
-  else
+for committed in "$backup"/*.ipynb; do
+  name=$(basename "$committed")
+  # nbdiff always exits 0, so a notebook is stale when it prints anything
+  # past its 3-line header
+  diff_out=$(nbdiff -I --no-color "$committed" "notebooks/$name" 2> /dev/null \
+             | tail -n +4)
+  if [ -n "$diff_out" ]; then
     status=1
-    echo "STALE: notebooks/$fname.ipynb does not match $fname.py"
+    echo "STALE: notebooks/$name does not match its .py source"
     echo "       regenerate it by running: util/gen_notebooks"
-    sed -n '1,40p' "$tmp/$fname.diff"
+    echo "$diff_out" | sed -n '1,40p'
   fi
 done
 
+if [ "$status" = 0 ]; then
+  echo "ok: every generated notebook matches its .py source"
+fi
 exit $status

--- a/util/check_notebooks
+++ b/util/check_notebooks
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# verify that notebooks/ matches the .py sources they are generated from,
+# i.e. that someone ran util/gen_notebooks after editing the .py file
+# usage: util/check_notebooks  (run from the root dir of this repo)
+#
+# jupytext assigns a fresh random id to every cell on each run, so ids are
+# stripped before comparing. Everything else must match exactly.
+
+set -u
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+status=0
+
+strip_ids() {
+  python3 -c "
+import json, sys
+nb = json.load(open(sys.argv[1]))
+for cell in nb.get('cells', []):
+  cell.pop('id', None)
+print(json.dumps(nb, indent=1, sort_keys=True))
+" "$1"
+}
+
+for fname in slimAttn_paper flashNorm_example; do
+  jupytext "$fname".py -o "$tmp/$fname".ipynb --quiet 2>/dev/null
+  strip_ids "notebooks/$fname.ipynb" > "$tmp/$fname.committed.json"
+  strip_ids "$tmp/$fname.ipynb"      > "$tmp/$fname.regenerated.json"
+  if diff -u "$tmp/$fname.committed.json" "$tmp/$fname.regenerated.json" \
+       > "$tmp/$fname.diff"; then
+    echo "ok:    notebooks/$fname.ipynb matches $fname.py"
+  else
+    status=1
+    echo "STALE: notebooks/$fname.ipynb does not match $fname.py"
+    echo "       regenerate it by running: util/gen_notebooks"
+    sed -n '1,40p' "$tmp/$fname.diff"
+  fi
+done
+
+exit $status

--- a/util/check_notebooks
+++ b/util/check_notebooks
@@ -7,28 +7,70 @@
 # then diffs the result against what is committed and puts the originals back.
 # Comparison is nbdiff -I (nbdime): content-aware, and -I ignores the cell ids
 # that jupytext regenerates on every run. Needs: pip install nbdime jupytext
+#
+# Fails CLOSED. If the tooling is missing, generation fails, or the differ
+# errors, this exits non-zero instead of reporting success -- a check that goes
+# green when its own tooling is broken is worse than no check at all.
 
 set -u
 
-if ! command -v nbdiff > /dev/null; then
+command -v jupytext > /dev/null || {
+  echo "check_notebooks: jupytext not found, install it with 'pip install jupytext'"
+  exit 2
+}
+command -v nbdiff > /dev/null || {
   echo "check_notebooks: nbdiff not found, install it with 'pip install nbdime'"
+  exit 2
+}
+
+shopt -s nullglob
+found=(notebooks/*.ipynb)
+if [ ${#found[@]} -eq 0 ]; then
+  echo "check_notebooks: no notebooks found in notebooks/, nothing to verify"
   exit 2
 fi
 
 backup=$(mktemp -d)
-cp notebooks/*.ipynb "$backup"/
+cp notebooks/*.ipynb "$backup"/ || {
+  echo "check_notebooks: could not back up notebooks/"
+  exit 2
+}
 # always put the committed notebooks back, however we exit
 trap 'cp "$backup"/*.ipynb notebooks/ 2> /dev/null; rm -rf "$backup"' EXIT
 
-util/gen_notebooks > /dev/null 2>&1
+marker="$backup/.marker"
+touch "$marker"
+
+if ! util/gen_notebooks > "$backup/gen.log" 2>&1; then
+  echo "check_notebooks: util/gen_notebooks failed, so nothing was verified"
+  sed -n '1,20p' "$backup/gen.log"
+  exit 2
+fi
+
+# Only the notebooks gen_notebooks just wrote are generated from a .py source.
+# Finding them by mtime keeps the list of generated files in gen_notebooks
+# alone, and skips the hand-authored notebooks, which are not derived from
+# anything and which nbdiff warns about because they carry no cell ids.
+regenerated=$(find notebooks -name '*.ipynb' -newer "$marker" | sort)
+if [ -z "$regenerated" ]; then
+  echo "check_notebooks: util/gen_notebooks wrote no notebooks, so nothing was verified"
+  exit 2
+fi
 
 status=0
-for committed in "$backup"/*.ipynb; do
-  name=$(basename "$committed")
-  # nbdiff always exits 0, so a notebook is stale when it prints anything
-  # past its 3-line header
-  diff_out=$(nbdiff -I --no-color "$committed" "notebooks/$name" 2> /dev/null \
-             | tail -n +4)
+for nb in $regenerated; do
+  name=$(basename "$nb")
+  # nbdiff exits 0 whether or not it finds a difference, so staleness is "did
+  # it print anything past its 3-line header". Its stderr is captured rather
+  # than discarded, so a crash in the differ surfaces instead of reading as a
+  # clean pass.
+  diff_out=$(nbdiff -I --no-color "$backup/$name" "$nb" \
+             2> "$backup/nbdiff.err" | tail -n +4)
+  if [ -s "$backup/nbdiff.err" ]; then
+    echo "check_notebooks: nbdiff errored on $name, so it was not verified"
+    sed -n '1,10p' "$backup/nbdiff.err"
+    exit 2
+  fi
   if [ -n "$diff_out" ]; then
     status=1
     echo "STALE: notebooks/$name does not match its .py source"

--- a/util/gen_notebooks
+++ b/util/gen_notebooks
@@ -3,6 +3,10 @@
 # generate Jupyter notebooks from python
 # usage: util/gen_notebooks  (run from the root dir of this repo)
 
+# -e so a failed conversion stops here and is visible, rather than being
+# masked by a later one succeeding (util/check_notebooks relies on this)
+set -e
+
 for fname in slimAttn_paper flashNorm_example; do
   jupytext "$fname".py -o notebooks/"$fname".ipynb
 done

--- a/util/push_pypi
+++ b/util/push_pypi
@@ -13,9 +13,15 @@ rm -rf pypi
 mkdir pypi
 cp ../LICENSE ../README.md ../pyproject.toml ../transformer_tricks.py pypi
 
-# build and upload
+# build, then upload unless we were only asked to build
+# (CI sets PUSH_PYPI_BUILD_ONLY=1 so it can verify the package still builds
+#  without publishing anything)
 cd pypi
 python3 -m build
+if [ "${PUSH_PYPI_BUILD_ONLY:-0}" = "1" ]; then
+  echo "PUSH_PYPI_BUILD_ONLY=1 -- built but not uploading"
+  exit 0
+fi
 python3 -m twine upload dist/*
 
 #rm -rf pypi


### PR DESCRIPTION
Fixes #3.

Split by cost, so the fast checks can gate every PR:

- **`ci.yml`** on push and pull_request: import smoke test, offline unit tests, notebook freshness, and a package build. Nothing downloads a model, so it finishes in a couple of minutes.
- **`daily.yml`** on a 06:17 UTC schedule plus `workflow_dispatch`: `flashNorm_test.py` end to end, which pulls SmolLM-135M/360M and runs perplexity. That is the "daily builds" half of the issue, with the HuggingFace cache preserved between runs.

## The notebook check found a real bug

`notebooks/` is generated from the `.py` sources by `util/gen_notebooks`, and `flashNorm_example.py` even ends with a note reminding you to run it. Nothing verified that anyone had. `util/check_notebooks` does, and it is runnable locally the same way as the other `util/` scripts. jupytext assigns a fresh random cell id on every run, so ids are stripped before comparing and only real drift is reported.

It immediately flagged `flashNorm_example.ipynb`, and the drift is not cosmetic. The published notebook does not work:

**Example 1** calls `flashify_repo(...)` with no `test=` argument. That writes `./SmolLM-135M_flashNorm`. The next line loads `./SmolLM-135M_flashNorm_test`, which is only written when `test=True` is passed explicitly, so the notebook fails on a missing directory.

**Example 2** never passes `strict=True`, so norm tensors are kept as all-ones, but it loads the result with `arch=LlamaFlashNorm`, the strict architecture.

The `.py` source was updated for compat/strict mode and the notebook was never regenerated. I regenerated just that one file here so CI starts green. I left `slimAttn_paper.ipynb` alone since regenerating it would only churn cell ids.

## What I left out

No lint job. `autopep8` with the settings in `pyproject.toml` currently wants to change roughly 2900 lines across the existing `.py` files, so turning that into a gate is a separate decision for you rather than something to slip into this PR.

## Verification

Every step was run locally before pushing: both workflow files parse, the import smoke test passes, `util/check_notebooks` reports both notebooks clean after the regeneration (and correctly reported the stale one before it), and the package build produces `transformer_tricks-0.4.1-py3-none-any.whl` plus the sdist.

The offline-test step uses an explicit filename list rather than a glob, because `flashNorm_test.py` needs the network and belongs in the daily job. On `main` today that list finds nothing and the step says so; it picks up `get_param_test.py` automatically if #19 lands. The two PRs are independent and can merge in either order.