### PR TITLE
slimAttn: precision study on Whisper cross-attention (Option 1 vs Option 2)

### DIFF
--- a/notebooks/slimAttn_whisper.ipynb
+++ b/notebooks/slimAttn_whisper.ipynb
@@ -1,0 +1,208 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c849d420",
+   "metadata": {},
+   "source": [
+    "Precision study for \"Slim Attention\" on Whisper cross-attention.\n",
+    "Usage: python3 slimAttn_whisper.py [model]   e.g. tiny, base, small (default)\n",
+    "\n",
+    "Slim attention caches one of K or V and recomputes the other:\n",
+    "  Option 1: cache K, V = K @ inv(Wk) @ Wv\n",
+    "  Option 2: cache V, K = V @ inv(Wv) @ Wk\n",
+    "Both halve the cache. This measures which one survives fp16 per layer, using\n",
+    "real encoder activations rather than random keys, because the two options\n",
+    "respond to real speech in opposite directions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "adc6f883",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet transformer_tricks datasets soundfile\n",
+    "import io\n",
+    "import sys\n",
+    "import torch\n",
+    "import soundfile as sf\n",
+    "from datasets import load_dataset, Audio\n",
+    "from transformers import WhisperForConditionalGeneration, WhisperFeatureExtractor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f808ccf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FP16_MAX = 65504.0  # largest finite fp16; W above this is not representable\n",
+    "BAD = 0.05          # relative error we treat as a failed reconstruction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b3309c0",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "source": [
+    "-------------------------------------------------------------------------------\n",
+    "defs\n",
+    "-------------------------------------------------------------------------------"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cc6767c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def real_activations(model, fe):\n",
+    "  \"\"\"Encoder output for one real utterance, float64. Random keys understate the\n",
+    "  error for Option 1 and overstate it for Option 2, so use real speech.\"\"\"\n",
+    "  ds = load_dataset('hf-internal-testing/librispeech_asr_dummy', 'clean', split='validation')\n",
+    "  ds = ds.cast_column('audio', Audio(decode=False))  # decode ourselves, no torchcodec\n",
+    "  raw = ds[0]['audio']\n",
+    "  wav, _ = sf.read(io.BytesIO(raw['bytes']) if raw.get('bytes') else raw['path'], dtype='float32')\n",
+    "  feats = fe(wav, sampling_rate=16000, return_tensors='pt').input_features\n",
+    "  with torch.no_grad():\n",
+    "    return model.model.encoder(feats).last_hidden_state[0].double()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3aa4af38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def reconstruct(A, B, X):\n",
+    "  \"\"\"Cache X@A.T, recompute X@B.T through W = inv(A) @ B built in float64.\n",
+    "  Returns max|W| and the fp16 relative error.\"\"\"\n",
+    "  W = torch.linalg.solve(A.T, B.T)  # more stable than forming inv(A) explicitly\n",
+    "  src, dst = X @ A.T, X @ B.T\n",
+    "  got = (src.to(torch.float16) @ W.to(torch.float16)).double()\n",
+    "  return W.abs().max().item(), ((got - dst).norm() / dst.norm()).item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "599c69bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def head_residual(Wk, Wv, heads):\n",
+    "  \"\"\"Can the choice be made per head? Only if rowspace(Wv[h]) sits inside\n",
+    "  rowspace(Wk[h]). Returns the mean least-squares residual over heads, where\n",
+    "  0 means per-head is exact and 1 means the subspaces do not overlap.\"\"\"\n",
+    "  dh = Wk.shape[0] // heads\n",
+    "  res = []\n",
+    "  for h in range(heads):\n",
+    "    A, B = Wk[h * dh:(h + 1) * dh, :].T, Wv[h * dh:(h + 1) * dh, :].T\n",
+    "    res.append(((A @ torch.linalg.lstsq(A, B).solution - B).norm() / B.norm()).item())\n",
+    "  return sum(res) / len(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8bc3a7e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#-------------------------------------------------------------------------------\n",
+    "# measure each cross-attention layer\n",
+    "#-------------------------------------------------------------------------------\n",
+    "name = sys.argv[1] if len(sys.argv) > 1 else 'small'\n",
+    "model = WhisperForConditionalGeneration.from_pretrained(f'openai/whisper-{name}').eval()\n",
+    "fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea69acdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = real_activations(model, fe)\n",
+    "Xrand = torch.randn_like(X) * X.std() + X.mean()  # matched mean and std"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94e21bb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'whisper-{name}: {tuple(X.shape)} real encoder activations\\n')\n",
+    "print(f'{\"layer\":>5} {\"cond(Wk)\":>9} {\"max|Wkv|\":>9} {\"opt1\":>7} {\"opt1rnd\":>8} '\n",
+    "      f'{\"cond(Wv)\":>9} {\"max|Wvk|\":>9} {\"opt2\":>7} {\"opt2rnd\":>8}  {\"use\":>7} {\"head\":>5}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f119d86a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rescued = neither = total = 0\n",
+    "for mod_name, mod in model.named_modules():\n",
+    "  if not mod_name.endswith('encoder_attn'):\n",
+    "    continue\n",
+    "  total += 1\n",
+    "  Wk = mod.k_proj.weight.detach().double()\n",
+    "  Wv = mod.v_proj.weight.detach().double()\n",
+    "\n",
+    "  w1, e1 = reconstruct(Wk, Wv, X)       # Option 1: cache K, recompute V\n",
+    "  w2, e2 = reconstruct(Wv, Wk, X)       # Option 2: cache V, recompute K\n",
+    "  _, e1r = reconstruct(Wk, Wv, Xrand)\n",
+    "  _, e2r = reconstruct(Wv, Wk, Xrand)\n",
+    "\n",
+    "  # a NaN error means W overflowed fp16, so treat it as failed\n",
+    "  bad1 = w1 > FP16_MAX or not e1 < BAD\n",
+    "  bad2 = w2 > FP16_MAX or not e2 < BAD\n",
+    "  use = 'opt1' if not bad1 else ('opt2' if not bad2 else 'neither')\n",
+    "  rescued += bad1 and not bad2\n",
+    "  neither += bad1 and bad2\n",
+    "\n",
+    "  layer = mod_name.replace('model.decoder.layers.', '').replace('.encoder_attn', '')\n",
+    "  print(f'{layer:>5} {torch.linalg.cond(Wk):9.1e} {w1:9.1e} {e1:7.3f} {e1r:8.3f} '\n",
+    "        f'{torch.linalg.cond(Wv):9.1e} {w2:9.1e} {e2:7.3f} {e2r:8.3f}  {use:>7} '\n",
+    "        f'{head_residual(Wk, Wv, mod.num_heads):5.2f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d768fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'\\nOption 2 rescues {rescued}/{total} layers that Option 1 loses; '\n",
+    "      f'{neither}/{total} survive neither.')\n",
+    "print('opt1 is worse on real speech than on random keys, opt2 is better, so the')\n",
+    "print('per-layer choice has to be calibrated on real activations.')\n",
+    "print('The head column is the per-head least-squares residual: near 1 everywhere,')\n",
+    "print('so Wkv mixes heads and the choice cannot be made per head.')"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/slimAttn_whisper.py
+++ b/slimAttn_whisper.py
@@ -1,0 +1,104 @@
+# Precision study for "Slim Attention" on Whisper cross-attention.
+# Usage: python3 slimAttn_whisper.py [model]   e.g. tiny, base, small (default)
+#
+# Slim attention caches one of K or V and recomputes the other:
+#   Option 1: cache K, V = K @ inv(Wk) @ Wv
+#   Option 2: cache V, K = V @ inv(Wv) @ Wk
+# Both halve the cache. This measures which one survives fp16 per layer, using
+# real encoder activations rather than random keys, because the two options
+# respond to real speech in opposite directions.
+
+# %pip install --quiet transformer_tricks datasets soundfile
+import io
+import sys
+import torch
+import soundfile as sf
+from datasets import load_dataset, Audio
+from transformers import WhisperForConditionalGeneration, WhisperFeatureExtractor
+
+FP16_MAX = 65504.0  # largest finite fp16; W above this is not representable
+BAD = 0.05          # relative error we treat as a failed reconstruction
+
+#-------------------------------------------------------------------------------
+# defs
+#-------------------------------------------------------------------------------
+
+
+def real_activations(model, fe):
+  """Encoder output for one real utterance, float64. Random keys understate the
+  error for Option 1 and overstate it for Option 2, so use real speech."""
+  ds = load_dataset('hf-internal-testing/librispeech_asr_dummy', 'clean', split='validation')
+  ds = ds.cast_column('audio', Audio(decode=False))  # decode ourselves, no torchcodec
+  raw = ds[0]['audio']
+  wav, _ = sf.read(io.BytesIO(raw['bytes']) if raw.get('bytes') else raw['path'], dtype='float32')
+  feats = fe(wav, sampling_rate=16000, return_tensors='pt').input_features
+  with torch.no_grad():
+    return model.model.encoder(feats).last_hidden_state[0].double()
+
+
+def reconstruct(A, B, X):
+  """Cache X@A.T, recompute X@B.T through W = inv(A) @ B built in float64.
+  Returns max|W| and the fp16 relative error."""
+  W = torch.linalg.solve(A.T, B.T)  # more stable than forming inv(A) explicitly
+  src, dst = X @ A.T, X @ B.T
+  got = (src.to(torch.float16) @ W.to(torch.float16)).double()
+  return W.abs().max().item(), ((got - dst).norm() / dst.norm()).item()
+
+
+def head_residual(Wk, Wv, heads):
+  """Can the choice be made per head? Only if rowspace(Wv[h]) sits inside
+  rowspace(Wk[h]). Returns the mean least-squares residual over heads, where
+  0 means per-head is exact and 1 means the subspaces do not overlap."""
+  dh = Wk.shape[0] // heads
+  res = []
+  for h in range(heads):
+    A, B = Wk[h * dh:(h + 1) * dh, :].T, Wv[h * dh:(h + 1) * dh, :].T
+    res.append(((A @ torch.linalg.lstsq(A, B).solution - B).norm() / B.norm()).item())
+  return sum(res) / len(res)
+
+
+#-------------------------------------------------------------------------------
+# measure each cross-attention layer
+#-------------------------------------------------------------------------------
+name = sys.argv[1] if len(sys.argv) > 1 else 'small'
+model = WhisperForConditionalGeneration.from_pretrained(f'openai/whisper-{name}').eval()
+fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')
+
+X = real_activations(model, fe)
+Xrand = torch.randn_like(X) * X.std() + X.mean()  # matched mean and std
+
+print(f'whisper-{name}: {tuple(X.shape)} real encoder activations\n')
+print(f'{"layer":>5} {"cond(Wk)":>9} {"max|Wkv|":>9} {"opt1":>7} {"opt1rnd":>8} '
+      f'{"cond(Wv)":>9} {"max|Wvk|":>9} {"opt2":>7} {"opt2rnd":>8}  {"use":>7} {"head":>5}')
+
+rescued = neither = total = 0
+for mod_name, mod in model.named_modules():
+  if not mod_name.endswith('encoder_attn'):
+    continue
+  total += 1
+  Wk = mod.k_proj.weight.detach().double()
+  Wv = mod.v_proj.weight.detach().double()
+
+  w1, e1 = reconstruct(Wk, Wv, X)       # Option 1: cache K, recompute V
+  w2, e2 = reconstruct(Wv, Wk, X)       # Option 2: cache V, recompute K
+  _, e1r = reconstruct(Wk, Wv, Xrand)
+  _, e2r = reconstruct(Wv, Wk, Xrand)
+
+  # a NaN error means W overflowed fp16, so treat it as failed
+  bad1 = w1 > FP16_MAX or not e1 < BAD
+  bad2 = w2 > FP16_MAX or not e2 < BAD
+  use = 'opt1' if not bad1 else ('opt2' if not bad2 else 'neither')
+  rescued += bad1 and not bad2
+  neither += bad1 and bad2
+
+  layer = mod_name.replace('model.decoder.layers.', '').replace('.encoder_attn', '')
+  print(f'{layer:>5} {torch.linalg.cond(Wk):9.1e} {w1:9.1e} {e1:7.3f} {e1r:8.3f} '
+        f'{torch.linalg.cond(Wv):9.1e} {w2:9.1e} {e2:7.3f} {e2r:8.3f}  {use:>7} '
+        f'{head_residual(Wk, Wv, mod.num_heads):5.2f}')
+
+print(f'\nOption 2 rescues {rescued}/{total} layers that Option 1 loses; '
+      f'{neither}/{total} survive neither.')
+print('opt1 is worse on real speech than on random keys, opt2 is better, so the')
+print('per-layer choice has to be calibrated on real activations.')
+print('The head column is the per-head least-squares residual: near 1 everywhere,')
+print('so Wkv mixes heads and the choice cannot be made per head.')

--- a/util/gen_notebooks
+++ b/util/gen_notebooks
@@ -7,6 +7,6 @@
 # masked by a later one succeeding (util/check_notebooks relies on this)
 set -e
 
-for fname in slimAttn_paper flashNorm_example; do
+for fname in slimAttn_paper slimAttn_whisper flashNorm_example; do
   jupytext "$fname".py -o notebooks/"$fname".ipynb
 done


### PR DESCRIPTION
Follow-up to the thread with @NilsGraf on slim attention and Whisper. Adds one script, `slimAttn_whisper.py`, and its generated notebook.

## What it measures

For each Whisper cross-attention layer, whether Option 1 (cache K, recompute V) or Option 2 (cache V, recompute K) survives fp16, using **real encoder activations** rather than random keys.

whisper-small:

```
layer  cond(Wk)  max|Wkv|    opt1  opt1rnd  cond(Wv)  max|Wvk|    opt2  opt2rnd      use  head
    0   2.0e+06   1.8e+04  26.461    2.682   2.9e+04   2.0e+02   0.029    0.070     opt2  0.90
    2   3.3e+07   2.2e+05     nan      nan   7.2e+03   3.4e+01   0.006    0.015     opt2  0.87
    3   3.0e+07   3.9e+05     nan      nan   2.1e+04   1.5e+02   0.022    0.034     opt2  0.88
    8   8.6e+03   7.9e+01   0.115    0.020   2.9e+04   4.6e+02   0.052    0.154  neither  0.91
    9   7.2e+03   8.1e+01   0.101    0.019   8.0e+04   2.4e+03   0.223    0.253  neither  0.92
   10   1.2e+04   1.2e+02   0.135    0.029   1.4e+04   2.5e+02   0.030    0.049     opt2  0.91
```

Option 2 rescues **10 of 12** layers. Layers 2 and 3 fail Option 1 by overflow, not precision: max|Wkv| of 2.2e5 and 3.9e5 against fp16's 65504, so those values aren't representable at all. The same layers need 34 and 151 the other direction.

Wk is far worse conditioned than Wv on most layers, but not all — on 8 and 9 cond(Wv) is larger — so the choice is per layer.

## Two findings the script exists to show

**Random keys give the wrong answer, in opposite directions.** Against noise with matched mean and std, real activations are 2.5–9.9x *worse* under Option 1 and 0.3–0.9x *better* under Option 2. Every layer follows that pattern. So calibrating the per-layer choice on synthetic keys assigns the wrong option to layers 8 and 10. Both columns are in the output (`opt1rnd`, `opt2rnd`) so it's checkable.

**The choice can't be made per head.** Per-head reconstruction needs rowspace(Wv[h]) inside rowspace(Wk[h]), and those are two 64-dim subspaces of R^768, so they generically meet only at zero. The `head` column is the mean per-head least-squares residual: 0.85–0.92 everywhere. Related: Wkv's on-block energy is 3.3–10% where chance for 12 heads is 8.3%, so it mixes heads about as much as a random matrix would.

Layers 8 and 9 survive neither direction on real speech, which leaves Option 3 for them.

## Notes

- Inverse built in float64 via `torch.linalg.solve` on the transposed system rather than forming `inv()`, per the guidance in the thread.
- Cross-attention only, since that's the block Option 2 removes for the 8.7x figure. Decoder self-attention and the encoder are untested.
- Verified on tiny, base and small. Max cond(Wk) grows roughly 1e4 → 6e5 → 3e7 across the three, so medium and large-v3 are the interesting cases and I haven't run them.
- `util/gen_notebooks` gains the new file; I reverted the incidental cell-id churn it produced on the two existing notebooks so the diff stays to the three intended files.
- New runtime deps (`datasets`, `soundfile`) are in the `%pip` line rather than `requirements.txt`, matching how `slimAttn_paper.py` handles torch and transformers.
