### PR TITLE
slimAttn_whisper: fix fp16-weight checkpoints, add medium and large-v3

### DIFF
--- a/notebooks/slimAttn_whisper.ipynb
+++ b/notebooks/slimAttn_whisper.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c849d420",
+   "id": "f03aa3f9",
    "metadata": {},
    "source": [
     "Precision study for \"Slim Attention\" on Whisper cross-attention.\n",
@@ -19,7 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adc6f883",
+   "id": "9419196e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f808ccf",
+   "id": "1f032a98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b3309c0",
+   "id": "fffca225",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -58,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cc6767c",
+   "id": "cefb887b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3aa4af38",
+   "id": "c92ad755",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "599c69bc",
+   "id": "f90eb3d7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bc3a7e1",
+   "id": "afe8cf5e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,14 +120,17 @@
     "# measure each cross-attention layer\n",
     "#-------------------------------------------------------------------------------\n",
     "name = sys.argv[1] if len(sys.argv) > 1 else 'small'\n",
-    "model = WhisperForConditionalGeneration.from_pretrained(f'openai/whisper-{name}').eval()\n",
+    "# large-v3 ships fp16 weights while the feature extractor emits float32, so\n",
+    "# load everything float32 and let the math below promote to float64.\n",
+    "model = WhisperForConditionalGeneration.from_pretrained(\n",
+    "    f'openai/whisper-{name}', dtype=torch.float32).eval()\n",
     "fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea69acdc",
+   "id": "5d37f5c5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94e21bb8",
+   "id": "6d4952c9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f119d86a",
+   "id": "cf0ca4b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d768fe6",
+   "id": "e4d4b916",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/slimAttn_whisper.py
+++ b/slimAttn_whisper.py
@@ -61,7 +61,10 @@ def head_residual(Wk, Wv, heads):
 # measure each cross-attention layer
 #-------------------------------------------------------------------------------
 name = sys.argv[1] if len(sys.argv) > 1 else 'small'
-model = WhisperForConditionalGeneration.from_pretrained(f'openai/whisper-{name}').eval()
+# large-v3 ships fp16 weights while the feature extractor emits float32, so
+# load everything float32 and let the math below promote to float64.
+model = WhisperForConditionalGeneration.from_pretrained(
+    f'openai/whisper-{name}', dtype=torch.float32).eval()
 fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')
 
 X = real_activations(model, fe)


### PR DESCRIPTION
Two things, both from trying to run the merged script on `large-v3`.

## The bug

`slimAttn_whisper.py` crashed on `whisper-large-v3`:

```
RuntimeError: Input type (float) and bias type (c10::Half) should be the same
```

Its config declares `torch_dtype: float16`, so weights load as half while the feature extractor emits float32, and the first encoder conv rejects the mix. `small` and below declare `float32`, which is why it never showed up. Loading float32 explicitly fixes it and changes nothing for the smaller models.

## What that unblocked

The earlier result stopped at `small`, and large-v3 is much worse:

| model | layers | Option 2 rescues | **survive neither** |
| --- | --- | --- | --- |
| tiny | 4 | 2 | 0 |
| base | 6 | 3 | 0 |
| small | 12 | 10 | 2 (17%) |
| medium | 24 | 19 | 5 (21%) |
| **large-v3** | 32 | 15 | **17 (53%)** |

On large-v3 **more than half the cross-attention layers reconstruct in neither direction under fp16**. `cond(W_K)` reaches 5.2e9 and eight layers overflow to NaN under Option 1 — but the reason Option 2 stops covering for them is that `cond(W_V)` degrades too, up to 4.5e6 on layer 14, where on `small` it stayed near 1e4 on every layer. On medium the same thing starts in the back half, layers 16 to 23.

So per-layer direction selection carries `small` and mostly carries `medium`, and stops being sufficient at `large-v3`.

## Two things I checked before claiming that

**It isn't fp16 storage noise.** large-v3's weights ship as fp16, so ill-conditioning could plausibly be a quantization artifact rather than a property of the matrix. Round-tripping `W_K` through fp16 again leaves `cond` unchanged to three significant figures (2.91e9 and 5.19e9 on layers 2 and 9). The conditioning is in the matrix.

**The trend is in the failure rate, not peak conditioning.** Max `cond(W_K)` is 3.3e7 on small and 1.1e7 on medium, so those two are not ordered. What grows monotonically is the share of layers that survive neither direction: 0, 0, 17%, 21%, 53%.

Worth noting large-v3 is both the size people deploy and the one that ships in the precision that breaks this.
