### PR TITLE
slimAttn_whisper: add Option 3, sweep which option survives which dtype

### DIFF
--- a/notebooks/slimAttn_whisper.ipynb
+++ b/notebooks/slimAttn_whisper.ipynb
@@ -2,24 +2,29 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f03aa3f9",
+   "id": "0c7cdd43",
    "metadata": {},
    "source": [
     "Precision study for \"Slim Attention\" on Whisper cross-attention.\n",
-    "Usage: python3 slimAttn_whisper.py [model]   e.g. tiny, base, small (default)\n",
+    "Usage: python3 slimAttn_whisper.py [model]    per-layer detail for one model\n",
+    "       python3 slimAttn_whisper.py --sweep    which option survives which dtype\n",
     "\n",
     "Slim attention caches one of K or V and recomputes the other:\n",
     "  Option 1: cache K, V = K @ inv(Wk) @ Wv\n",
     "  Option 2: cache V, K = V @ inv(Wv) @ Wk\n",
     "Both halve the cache. This measures which one survives fp16 per layer, using\n",
     "real encoder activations rather than random keys, because the two options\n",
-    "respond to real speech in opposite directions."
+    "respond to real speech in opposite directions.\n",
+    "\n",
+    "--sweep adds Option 3 (cache X, recompute both K and V). It needs no inverse,\n",
+    "so it has no conditioning to lose, and it is the only option that survives\n",
+    "bf16. Option 1 turns out never to survive fp16 at any model size."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9419196e",
+   "id": "373dfbc6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f032a98",
+   "id": "2f95baa7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +50,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fffca225",
+   "id": "5082561d",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -58,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cefb887b",
+   "id": "d3e0afed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c92ad755",
+   "id": "89b11dad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f90eb3d7",
+   "id": "ad76a333",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +117,55 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "afe8cf5e",
+   "id": "6b97cca7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sweep(models=('tiny', 'base', 'small', 'medium', 'large-v3'), bad=0.05):\n",
+    "  \"\"\"Layers under `bad` relative error, per option per dtype, per model.\"\"\"\n",
+    "  dtypes = {'fp32': torch.float32, 'fp16': torch.float16, 'bf16': torch.bfloat16}\n",
+    "  print(f'layers under {bad:.0%} relative error, X from a real encoder pass\\n')\n",
+    "  print(f'{\"model\":>9} {\"dtype\":>6} {\"opt1\":>7} {\"opt2\":>7} {\"opt3\":>7}')\n",
+    "  for name in models:\n",
+    "    m = WhisperForConditionalGeneration.from_pretrained(\n",
+    "        f'openai/whisper-{name}', dtype=torch.float32).eval()\n",
+    "    fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')\n",
+    "    X = real_activations(m, fe)\n",
+    "    attn = [mod for n_, mod in m.named_modules() if n_.endswith('encoder_attn')]\n",
+    "    for dname, dt in dtypes.items():\n",
+    "      ok = [0, 0, 0]\n",
+    "      for mod in attn:\n",
+    "        Wk = mod.k_proj.weight.detach().double()\n",
+    "        Wv = mod.v_proj.weight.detach().double()\n",
+    "        K, V = X @ Wk.T, X @ Wv.T\n",
+    "        e1 = ((K.to(dt) @ torch.linalg.solve(Wk.T, Wv.T).to(dt)).double() - V).norm() / V.norm()\n",
+    "        e2 = ((V.to(dt) @ torch.linalg.solve(Wv.T, Wk.T).to(dt)).double() - K).norm() / K.norm()\n",
+    "        Xd = X.to(dt)   # option 3: no inverse, just the two original projections\n",
+    "        e3 = max(((Xd @ Wk.T.to(dt)).double() - K).norm() / K.norm(),\n",
+    "                 ((Xd @ Wv.T.to(dt)).double() - V).norm() / V.norm())\n",
+    "        for i, e in enumerate((e1, e2, e3)):\n",
+    "          ok[i] += e < bad\n",
+    "      n_ = len(attn)\n",
+    "      print(f'{name:>9} {dname:>6} {ok[0]:>4}/{n_:<2} {ok[1]:>4}/{n_:<2} {ok[2]:>4}/{n_:<2}')\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47be5c78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if len(sys.argv) > 1 and sys.argv[1] == '--sweep':\n",
+    "  sweep()\n",
+    "  sys.exit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0089217c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d37f5c5",
+   "id": "5601c561",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d4952c9",
+   "id": "eb3ae6a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf0ca4b5",
+   "id": "ae435400",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4d4b916",
+   "id": "96d5a4f2",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/slimAttn_whisper.py
+++ b/slimAttn_whisper.py
@@ -1,5 +1,6 @@
 # Precision study for "Slim Attention" on Whisper cross-attention.
-# Usage: python3 slimAttn_whisper.py [model]   e.g. tiny, base, small (default)
+# Usage: python3 slimAttn_whisper.py [model]    per-layer detail for one model
+#        python3 slimAttn_whisper.py --sweep    which option survives which dtype
 #
 # Slim attention caches one of K or V and recomputes the other:
 #   Option 1: cache K, V = K @ inv(Wk) @ Wv
@@ -7,6 +8,10 @@
 # Both halve the cache. This measures which one survives fp16 per layer, using
 # real encoder activations rather than random keys, because the two options
 # respond to real speech in opposite directions.
+#
+# --sweep adds Option 3 (cache X, recompute both K and V). It needs no inverse,
+# so it has no conditioning to lose, and it is the only option that survives
+# bf16. Option 1 turns out never to survive fp16 at any model size.
 
 # %pip install --quiet transformer_tricks datasets soundfile
 import io
@@ -56,6 +61,39 @@ def head_residual(Wk, Wv, heads):
     res.append(((A @ torch.linalg.lstsq(A, B).solution - B).norm() / B.norm()).item())
   return sum(res) / len(res)
 
+
+def sweep(models=('tiny', 'base', 'small', 'medium', 'large-v3'), bad=0.05):
+  """Layers under `bad` relative error, per option per dtype, per model."""
+  dtypes = {'fp32': torch.float32, 'fp16': torch.float16, 'bf16': torch.bfloat16}
+  print(f'layers under {bad:.0%} relative error, X from a real encoder pass\n')
+  print(f'{"model":>9} {"dtype":>6} {"opt1":>7} {"opt2":>7} {"opt3":>7}')
+  for name in models:
+    m = WhisperForConditionalGeneration.from_pretrained(
+        f'openai/whisper-{name}', dtype=torch.float32).eval()
+    fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')
+    X = real_activations(m, fe)
+    attn = [mod for n_, mod in m.named_modules() if n_.endswith('encoder_attn')]
+    for dname, dt in dtypes.items():
+      ok = [0, 0, 0]
+      for mod in attn:
+        Wk = mod.k_proj.weight.detach().double()
+        Wv = mod.v_proj.weight.detach().double()
+        K, V = X @ Wk.T, X @ Wv.T
+        e1 = ((K.to(dt) @ torch.linalg.solve(Wk.T, Wv.T).to(dt)).double() - V).norm() / V.norm()
+        e2 = ((V.to(dt) @ torch.linalg.solve(Wv.T, Wk.T).to(dt)).double() - K).norm() / K.norm()
+        Xd = X.to(dt)   # option 3: no inverse, just the two original projections
+        e3 = max(((Xd @ Wk.T.to(dt)).double() - K).norm() / K.norm(),
+                 ((Xd @ Wv.T.to(dt)).double() - V).norm() / V.norm())
+        for i, e in enumerate((e1, e2, e3)):
+          ok[i] += e < bad
+      n_ = len(attn)
+      print(f'{name:>9} {dname:>6} {ok[0]:>4}/{n_:<2} {ok[1]:>4}/{n_:<2} {ok[2]:>4}/{n_:<2}')
+    print()
+
+
+if len(sys.argv) > 1 and sys.argv[1] == '--sweep':
+  sweep()
+  sys.exit()
 
 #-------------------------------------------------------------------------------
 # measure each cross-attention layer


### PR DESCRIPTION
You asked whether this summary is right:

> - Option 3 (store X) should work for all cases (all models, all data types)
> - Slim attention (store K, or store V) only works for FP32 for all models. And for tiny and base models only, FP16 (and or BF16) also works.

First bullet holds. Second needs three corrections. `--sweep` measures all three options across all five models and three dtypes, counting layers under 5% relative error with X from a real encoder pass:

```
  model      dtype   opt1     opt2     opt3
  tiny       fp32    4/4      4/4      4/4
  tiny       fp16    0/4      4/4      4/4
  tiny       bf16    0/4      1/4      4/4
  base       fp32    6/6      6/6      6/6
  base       fp16    0/6      6/6      6/6
  base       bf16    0/6      1/6      6/6
  small      fp32   11/12    12/12    12/12
  small      fp16    0/12    10/12    12/12
  small      bf16    0/12     1/12    12/12
  medium     fp32   24/24    24/24    24/24
  medium     fp16    0/24    19/24    24/24
  medium     bf16    0/24     0/24    24/24
  large-v3   fp32   26/32    32/32    32/32
  large-v3   fp16    0/32    15/32    32/32
  large-v3   bf16    0/32     0/32    32/32
```

**Option 3 is 100% everywhere**, so the first bullet is confirmed. Worst error 6.3e-7 fp32, 3.1e-4 fp16, 3.1e-3 bf16 — matmul rounding, since nothing is inverted.

**Option 1 never survives fp16, at any size, including tiny.** Zero layers. My earlier framing of "Option 2 rescues N of M" left the impression Option 1 carries the small models; it carries none of them.

**fp32 is not universal for Option 1 either** — 11/12 on small, 26/32 on large-v3. Option 2 is the one that is 100% in fp32 at every size.

**bf16 is worse than the parenthetical suggests.** Best case is 1 layer on tiny, base and small, and 0 on medium and large-v3. Only Option 3 survives it.

So a version I'd believe:

- Option 3 works for all models and all dtypes tested, at the cost of a second matmul.
- Option 2 works in fp32 for every model, and in fp16 fully for tiny and base, partially above that (10/12, 19/24, 15/32).
- Option 1 works only in fp32, and not everywhere even there.
- Neither Option 1 nor Option 2 is usable in bf16.

Folded into the existing script rather than adding a file, per CONTRIBUTING. Single-model mode is unchanged; `--sweep` is the new path. The 5% threshold is a judgement call so it's a parameter, not baked in.
