### PR TITLE
weight(): name cross-attention keys, and actually use the package in slimAttn_whisper

### DIFF
--- a/notebooks/slimAttn_whisper.ipynb
+++ b/notebooks/slimAttn_whisper.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "0c7cdd43",
+   "id": "ebad4c4d",
    "metadata": {},
    "source": [
     "Precision study for \"Slim Attention\" on Whisper cross-attention.\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "373dfbc6",
+   "id": "3f4424a6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,6 +33,7 @@
     "import sys\n",
     "import torch\n",
     "import soundfile as sf\n",
+    "import transformer_tricks as tt\n",
     "from datasets import load_dataset, Audio\n",
     "from transformers import WhisperForConditionalGeneration, WhisperFeatureExtractor"
    ]
@@ -40,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f95baa7",
+   "id": "2e18f3b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,8 +50,30 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c2885ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# where Whisper keeps cross-attention, for tt.weight(). Its decoder layers hold\n",
+    "# both self_attn and encoder_attn; slim attention only concerns the latter.\n",
+    "STACK, XATTN = 'model.decoder.layers', 'encoder_attn'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dc38220",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tt.quiet_hf()"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "5082561d",
+   "id": "332241b4",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -63,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3e0afed",
+   "id": "5bab480e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89b11dad",
+   "id": "caec7624",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad76a333",
+   "id": "0a8cba5d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b97cca7",
+   "id": "45fc8efc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,12 +154,13 @@
     "        f'openai/whisper-{name}', dtype=torch.float32).eval()\n",
     "    fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')\n",
     "    X = real_activations(m, fe)\n",
-    "    attn = [mod for n_, mod in m.named_modules() if n_.endswith('encoder_attn')]\n",
+    "    param = m.state_dict()  # views of the loaded weights, so no second copy\n",
+    "    n_ = m.config.decoder_layers\n",
     "    for dname, dt in dtypes.items():\n",
     "      ok = [0, 0, 0]\n",
-    "      for mod in attn:\n",
-    "        Wk = mod.k_proj.weight.detach().double()\n",
-    "        Wv = mod.v_proj.weight.detach().double()\n",
+    "      for layer in range(n_):\n",
+    "        Wk = param[tt.weight('K', layer, stack=STACK, attn=XATTN)].double()\n",
+    "        Wv = param[tt.weight('V', layer, stack=STACK, attn=XATTN)].double()\n",
     "        K, V = X @ Wk.T, X @ Wv.T\n",
     "        e1 = ((K.to(dt) @ torch.linalg.solve(Wk.T, Wv.T).to(dt)).double() - V).norm() / V.norm()\n",
     "        e2 = ((V.to(dt) @ torch.linalg.solve(Wv.T, Wk.T).to(dt)).double() - K).norm() / K.norm()\n",
@@ -145,7 +169,6 @@
     "                 ((Xd @ Wv.T.to(dt)).double() - V).norm() / V.norm())\n",
     "        for i, e in enumerate((e1, e2, e3)):\n",
     "          ok[i] += e < bad\n",
-    "      n_ = len(attn)\n",
     "      print(f'{name:>9} {dname:>6} {ok[0]:>4}/{n_:<2} {ok[1]:>4}/{n_:<2} {ok[2]:>4}/{n_:<2}')\n",
     "    print()"
    ]
@@ -153,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47be5c78",
+   "id": "10f1bb7b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0089217c",
+   "id": "cc7dcea6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,18 +206,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5601c561",
+   "id": "41789aad",
    "metadata": {},
    "outputs": [],
    "source": [
     "X = real_activations(model, fe)\n",
+    "torch.manual_seed(0)  # so the random baseline is reproducible run to run\n",
     "Xrand = torch.randn_like(X) * X.std() + X.mean()  # matched mean and std"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb3ae6a6",
+   "id": "8e561624",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,17 +230,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae435400",
+   "id": "db64bd52",
    "metadata": {},
    "outputs": [],
    "source": [
-    "rescued = neither = total = 0\n",
-    "for mod_name, mod in model.named_modules():\n",
-    "  if not mod_name.endswith('encoder_attn'):\n",
-    "    continue\n",
-    "  total += 1\n",
-    "  Wk = mod.k_proj.weight.detach().double()\n",
-    "  Wv = mod.v_proj.weight.detach().double()\n",
+    "param = model.state_dict()  # views of the loaded weights, so no second copy\n",
+    "rescued = neither = 0\n",
+    "total = model.config.decoder_layers\n",
+    "for layer in range(total):\n",
+    "  Wk = param[tt.weight('K', layer, stack=STACK, attn=XATTN)].double()\n",
+    "  Wv = param[tt.weight('V', layer, stack=STACK, attn=XATTN)].double()\n",
     "\n",
     "  w1, e1 = reconstruct(Wk, Wv, X)       # Option 1: cache K, recompute V\n",
     "  w2, e2 = reconstruct(Wv, Wk, X)       # Option 2: cache V, recompute K\n",
@@ -230,16 +253,15 @@
     "  rescued += bad1 and not bad2\n",
     "  neither += bad1 and bad2\n",
     "\n",
-    "  layer = mod_name.replace('model.decoder.layers.', '').replace('.encoder_attn', '')\n",
     "  print(f'{layer:>5} {torch.linalg.cond(Wk):9.1e} {w1:9.1e} {e1:7.3f} {e1r:8.3f} '\n",
     "        f'{torch.linalg.cond(Wv):9.1e} {w2:9.1e} {e2:7.3f} {e2r:8.3f}  {use:>7} '\n",
-    "        f'{head_residual(Wk, Wv, mod.num_heads):5.2f}')"
+    "        f'{head_residual(Wk, Wv, model.config.decoder_attention_heads):5.2f}')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96d5a4f2",
+   "id": "9e036f52",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 [project]
 name = "transformer-tricks"
 # version numbering A.B.C: A is major version, B is minor version, and C is patch
-version = "0.4.1"
+version = "0.5.0"
 authors = [
   {name="Open Machine", email="info@openmachine.ai"},
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformer-tricks>=0.4.1
+transformer-tricks>=0.5.0
 jupytext>=1.16.4
 autopep8>=2.3.1
 twine>=6.1.0

--- a/slimAttn_whisper.py
+++ b/slimAttn_whisper.py
@@ -18,11 +18,18 @@ import io
 import sys
 import torch
 import soundfile as sf
+import transformer_tricks as tt
 from datasets import load_dataset, Audio
 from transformers import WhisperForConditionalGeneration, WhisperFeatureExtractor
 
 FP16_MAX = 65504.0  # largest finite fp16; W above this is not representable
 BAD = 0.05          # relative error we treat as a failed reconstruction
+
+# where Whisper keeps cross-attention, for tt.weight(). Its decoder layers hold
+# both self_attn and encoder_attn; slim attention only concerns the latter.
+STACK, XATTN = 'model.decoder.layers', 'encoder_attn'
+
+tt.quiet_hf()
 
 #-------------------------------------------------------------------------------
 # defs
@@ -72,12 +79,13 @@ def sweep(models=('tiny', 'base', 'small', 'medium', 'large-v3'), bad=0.05):
         f'openai/whisper-{name}', dtype=torch.float32).eval()
     fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')
     X = real_activations(m, fe)
-    attn = [mod for n_, mod in m.named_modules() if n_.endswith('encoder_attn')]
+    param = m.state_dict()  # views of the loaded weights, so no second copy
+    n_ = m.config.decoder_layers
     for dname, dt in dtypes.items():
       ok = [0, 0, 0]
-      for mod in attn:
-        Wk = mod.k_proj.weight.detach().double()
-        Wv = mod.v_proj.weight.detach().double()
+      for layer in range(n_):
+        Wk = param[tt.weight('K', layer, stack=STACK, attn=XATTN)].double()
+        Wv = param[tt.weight('V', layer, stack=STACK, attn=XATTN)].double()
         K, V = X @ Wk.T, X @ Wv.T
         e1 = ((K.to(dt) @ torch.linalg.solve(Wk.T, Wv.T).to(dt)).double() - V).norm() / V.norm()
         e2 = ((V.to(dt) @ torch.linalg.solve(Wv.T, Wk.T).to(dt)).double() - K).norm() / K.norm()
@@ -86,7 +94,6 @@ def sweep(models=('tiny', 'base', 'small', 'medium', 'large-v3'), bad=0.05):
                  ((Xd @ Wv.T.to(dt)).double() - V).norm() / V.norm())
         for i, e in enumerate((e1, e2, e3)):
           ok[i] += e < bad
-      n_ = len(attn)
       print(f'{name:>9} {dname:>6} {ok[0]:>4}/{n_:<2} {ok[1]:>4}/{n_:<2} {ok[2]:>4}/{n_:<2}')
     print()
 
@@ -106,19 +113,19 @@ model = WhisperForConditionalGeneration.from_pretrained(
 fe = WhisperFeatureExtractor.from_pretrained(f'openai/whisper-{name}')
 
 X = real_activations(model, fe)
+torch.manual_seed(0)  # so the random baseline is reproducible run to run
 Xrand = torch.randn_like(X) * X.std() + X.mean()  # matched mean and std
 
 print(f'whisper-{name}: {tuple(X.shape)} real encoder activations\n')
 print(f'{"layer":>5} {"cond(Wk)":>9} {"max|Wkv|":>9} {"opt1":>7} {"opt1rnd":>8} '
       f'{"cond(Wv)":>9} {"max|Wvk|":>9} {"opt2":>7} {"opt2rnd":>8}  {"use":>7} {"head":>5}')
 
-rescued = neither = total = 0
-for mod_name, mod in model.named_modules():
-  if not mod_name.endswith('encoder_attn'):
-    continue
-  total += 1
-  Wk = mod.k_proj.weight.detach().double()
-  Wv = mod.v_proj.weight.detach().double()
+param = model.state_dict()  # views of the loaded weights, so no second copy
+rescued = neither = 0
+total = model.config.decoder_layers
+for layer in range(total):
+  Wk = param[tt.weight('K', layer, stack=STACK, attn=XATTN)].double()
+  Wv = param[tt.weight('V', layer, stack=STACK, attn=XATTN)].double()
 
   w1, e1 = reconstruct(Wk, Wv, X)       # Option 1: cache K, recompute V
   w2, e2 = reconstruct(Wv, Wk, X)       # Option 2: cache V, recompute K
@@ -132,10 +139,9 @@ for mod_name, mod in model.named_modules():
   rescued += bad1 and not bad2
   neither += bad1 and bad2
 
-  layer = mod_name.replace('model.decoder.layers.', '').replace('.encoder_attn', '')
   print(f'{layer:>5} {torch.linalg.cond(Wk):9.1e} {w1:9.1e} {e1:7.3f} {e1r:8.3f} '
         f'{torch.linalg.cond(Wv):9.1e} {w2:9.1e} {e2:7.3f} {e2r:8.3f}  {use:>7} '
-        f'{head_residual(Wk, Wv, mod.num_heads):5.2f}')
+        f'{head_residual(Wk, Wv, model.config.decoder_attention_heads):5.2f}')
 
 print(f'\nOption 2 rescues {rescued}/{total} layers that Option 1 loses; '
       f'{neither}/{total} survive neither.')

--- a/transformer_tricks.py
+++ b/transformer_tricks.py
@@ -26,18 +26,25 @@ def quiet_hf():
   # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables
 
 
-def weight(name, layer=0):
-  """get dictionary key of specific weight (such as Q from layer 0)"""
-  layer_str = 'model.layers.' + str(layer) + '.'
+def weight(name, layer=0, stack='model.layers', attn='self_attn'):
+  """get dictionary key of specific weight (such as Q from layer 0)
+
+  The defaults name a decoder-only model such as Llama. 'stack' and 'attn'
+  redirect the attention projections so encoder-decoder models can be named too,
+  e.g. Whisper cross-attention K is
+    weight('K', layer, stack='model.decoder.layers', attn='encoder_attn')
+  Only QKV, Q, K, V and O move with 'attn'. The MLP and norm keys keep Llama's
+  names, and so does o_proj, which Whisper spells out_proj."""
+  layer_str = stack + '.' + str(layer) + '.'
   match name:
     # weights of each layer
     case 'Inorm': key = layer_str + 'input_layernorm.weight'
     case 'Anorm': key = layer_str + 'post_attention_layernorm.weight'
-    case 'QKV'  : key = layer_str + 'self_attn.qkv_proj.weight'
-    case 'Q'    : key = layer_str + 'self_attn.q_proj.weight'
-    case 'K'    : key = layer_str + 'self_attn.k_proj.weight'
-    case 'V'    : key = layer_str + 'self_attn.v_proj.weight'
-    case 'O'    : key = layer_str + 'self_attn.o_proj.weight'
+    case 'QKV'  : key = layer_str + attn + '.qkv_proj.weight'
+    case 'Q'    : key = layer_str + attn + '.q_proj.weight'
+    case 'K'    : key = layer_str + attn + '.k_proj.weight'
+    case 'V'    : key = layer_str + attn + '.v_proj.weight'
+    case 'O'    : key = layer_str + attn + '.o_proj.weight'
     case 'GU'   : key = layer_str + 'mlp.gate_up_proj.weight'
     case 'G'    : key = layer_str + 'mlp.gate_proj.weight'
     case 'U'    : key = layer_str + 'mlp.up_proj.weight'


### PR DESCRIPTION
Answering your comment on #23 about using the package's own defs.

You were right that something was off: `slimAttn_whisper.py` line 16 tells people to `pip install transformer_tricks` and then never imports it.

## What fits, and what doesn't

- **`tt.quiet_hf()`** — drop-in, now used.
- **`tt.get_param()`** — doesn't fit here. This script needs a live model to run the encoder forward pass and get real activations, so reading the safetensors separately would load large-v3's weights a second time, about 6GB. Instead it reads `model.state_dict()`, whose keys are exactly the safetensors keys and whose tensors are **views of the already loaded weights**, so `tt.weight()` still does the naming with no extra copy.
- **`tt.weight()`** — didn't work at all, which is the substance of this PR.

## The gap in `weight()`

It only spoke Llama. `weight('K', 3)` returned `model.layers.3.self_attn.k_proj.weight`, so there was no way to name a cross-attention weight in **any** encoder-decoder model, not just Whisper. Since the package is meant to serve tricks beyond slim attention, that seemed worth fixing in the package rather than working around in my file.

Added `stack` and `attn` with the current values as defaults, so every existing call is byte-for-byte unchanged:

```python
weight('K', 3)  # model.layers.3.self_attn.k_proj.weight, as before
weight('K', 3, stack='model.decoder.layers', attn='encoder_attn')
# model.decoder.layers.3.encoder_attn.k_proj.weight
```

Verified this also names BART (`model.decoder.layers.0.encoder_attn.k_proj.weight`, confirmed present in its state dict). **It does not cover T5**, which is `decoder.block.0.layer.1.EncDecAttention.k.weight` — a different container name, an extra nesting level, and `k` instead of `k_proj`. That needs more than a prefix swap, so I left it out rather than half-support it.

**Scope limit, stated in the docstring:** only `QKV/Q/K/V/O` move with `attn`. The MLP and norm keys keep Llama's names, and so does `o_proj`, which Whisper spells `out_proj`. I left those alone rather than guess at a general mapping. Q/K/V is what slim attention needs.

## Verification

The refactor had to change no numbers, so I checked rather than assumed:

- With the same seed applied to both, the per-layer table **and** the full `--sweep` are **bit-identical** before and after.
- All 10 existing `weight()` names still resolve to their original keys.
- `util/check_notebooks` passes, `autopep8` is clean.

## Two things worth flagging

**1. The random baseline was unseeded.** `torch.randn_like` had no seed, so `opt1rnd` and `opt2rnd` changed on every run. I found this because my first before/after diff showed a mismatch, and the old script turned out to differ from *itself* across two runs. Added `torch.manual_seed(0)`. Those columns are now reproducible, which matters if any of these numbers end up in the paper.

**2. The Colab notebook needs 0.5.0 published before it runs green.** The notebook's `%pip install transformer_tricks` pulls from PyPI, so until the new package is out it will get 0.4.1 and raise `TypeError` on the new kwargs. Locally it's fine, since the script imports the repo file. I bumped `pyproject.toml` and `requirements.txt` to 0.5.0 per CONTRIBUTING but did not run `push_pypi.sh` — that's yours to do. Happy to split the `weight()` change into its own PR if you'd rather publish before the Whisper script starts depending on it.
