### PR TITLE
slimAttn_whisper: read the layer count inline, per your review on #24

### DIFF
--- a/notebooks/slimAttn_whisper.ipynb
+++ b/notebooks/slimAttn_whisper.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ebad4c4d",
+   "id": "5eec8547",
    "metadata": {},
    "source": [
     "Precision study for \"Slim Attention\" on Whisper cross-attention.\n",
@@ -24,7 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f4424a6",
+   "id": "67fc143f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e18f3b3",
+   "id": "048d1075",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c2885ac",
+   "id": "8df64879",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0dc38220",
+   "id": "020ca9ad",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "332241b4",
+   "id": "957240e1",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bab480e",
+   "id": "bb1d3a22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "caec7624",
+   "id": "0e25f289",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a8cba5d",
+   "id": "22db1c2b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45fc8efc",
+   "id": "b6c06d22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10f1bb7b",
+   "id": "cc84d11b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc7dcea6",
+   "id": "e7617b80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41789aad",
+   "id": "1e3a1515",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e561624",
+   "id": "955e973e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,14 +230,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db64bd52",
+   "id": "c555bebb",
    "metadata": {},
    "outputs": [],
    "source": [
     "param = model.state_dict()  # views of the loaded weights, so no second copy\n",
     "rescued = neither = 0\n",
-    "total = model.config.decoder_layers\n",
-    "for layer in range(total):\n",
+    "for layer in range(model.config.decoder_layers):\n",
     "  Wk = param[tt.weight('K', layer, stack=STACK, attn=XATTN)].double()\n",
     "  Wv = param[tt.weight('V', layer, stack=STACK, attn=XATTN)].double()\n",
     "\n",
@@ -261,12 +260,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e036f52",
+   "id": "95d9b190",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'\\nOption 2 rescues {rescued}/{total} layers that Option 1 loses; '\n",
-    "      f'{neither}/{total} survive neither.')\n",
+    "n_layers = model.config.decoder_layers\n",
+    "print(f'\\nOption 2 rescues {rescued}/{n_layers} layers that Option 1 loses; '\n",
+    "      f'{neither}/{n_layers} survive neither.')\n",
     "print('opt1 is worse on real speech than on random keys, opt2 is better, so the')\n",
     "print('per-layer choice has to be calibrated on real activations.')\n",
     "print('The head column is the per-head least-squares residual: near 1 everywhere,')\n",

--- a/slimAttn_whisper.py
+++ b/slimAttn_whisper.py
@@ -122,8 +122,7 @@ print(f'{"layer":>5} {"cond(Wk)":>9} {"max|Wkv|":>9} {"opt1":>7} {"opt1rnd":>8} 
 
 param = model.state_dict()  # views of the loaded weights, so no second copy
 rescued = neither = 0
-total = model.config.decoder_layers
-for layer in range(total):
+for layer in range(model.config.decoder_layers):
   Wk = param[tt.weight('K', layer, stack=STACK, attn=XATTN)].double()
   Wv = param[tt.weight('V', layer, stack=STACK, attn=XATTN)].double()
 
@@ -143,8 +142,9 @@ for layer in range(total):
         f'{torch.linalg.cond(Wv):9.1e} {w2:9.1e} {e2:7.3f} {e2r:8.3f}  {use:>7} '
         f'{head_residual(Wk, Wv, model.config.decoder_attention_heads):5.2f}')
 
-print(f'\nOption 2 rescues {rescued}/{total} layers that Option 1 loses; '
-      f'{neither}/{total} survive neither.')
+n_layers = model.config.decoder_layers
+print(f'\nOption 2 rescues {rescued}/{n_layers} layers that Option 1 loses; '
+      f'{neither}/{n_layers} survive neither.')
 print('opt1 is worse on real speech than on random keys, opt2 is better, so the')
 print('per-layer choice has to be calibrated on real activations.')
 print('The head column is the per-head least-squares residual: near 1 everywhere,')


### PR DESCRIPTION
Your review note on #24. The loop now reads exactly as you wrote it:

```python
for layer in range(model.config.decoder_layers):
```

`total` was a leftover from before the refactor, where it was a counter incremented inside the loop. Once the loop became a `range`, it was only an alias for the config value, so the hop through it bought nothing. This also matches how `flashify` already writes the same thing.

The summary line at the bottom needs the count twice, so it keeps a small local instead of repeating the attribute lookup three times in one f-string. Happy to inline that too if you'd rather.

Verified no behaviour change: the per-layer table and the full `--sweep` are identical before and after.